### PR TITLE
Add file-backed blob storage backend with safe chunked uploads

### DIFF
--- a/docs/features/inter-component/blob_storage.rst
+++ b/docs/features/inter-component/blob_storage.rst
@@ -5,6 +5,19 @@
 Blob Storage
 ------------
 
+The large result store has two backends, selected via the ``type`` field of
+the ``large_result_store`` configuration block:
+
+- ``azure`` — Azure Blob Storage (see below).
+- ``file`` — local filesystem (see :ref:`file-storage-backend`).
+
+If ``type`` is omitted, ``file`` is assumed.
+If ``type`` is unrecognised, the large result store is disabled and a
+warning is logged at startup.
+
+Azure backend
++++++++++++++
+
 To use Azure Blob Storage, the following can be set in the server
 configuration file:
 
@@ -18,10 +31,10 @@ configuration file:
     client_secret: "your-client-secret"
     storage_account_name: "your-storage-account-name"
 
-At the moment, only the 'azure' storage type is supported. The 'test-container' refers to the azure blob container 
-(unrelated to Docker containers) in which all blobs are stored. This container should be created in advance manually. 
-Tenant id, client id and client secret are required for authentication (For help on setting up a managed identity, 
-see `here <https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory>`__). 
+The 'test-container' refers to the azure blob container
+(unrelated to Docker containers) in which all blobs are stored. This container should be created in advance manually.
+Tenant id, client id and client secret are required for authentication (For help on setting up a managed identity,
+see `here <https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory>`__).
 
 For development and testing purposes, `Azurite 
 <https://github.com/Azure/Azurite>`__ can be used. There are subtle differences
@@ -44,6 +57,42 @@ point to a local Azurite instance.
     Note that while it is also possible to use a connection string to connect to Azure Blob Storage,
     it is not recommended (accountname and accountkey will be stored plainly in the configuration,
     no automatic rotation, no fine-grained permissions via RBAC and so on).
+
+.. _file-storage-backend:
+
+File backend
+++++++++++++
+
+To store blobs on the local filesystem instead of Azure, set ``type`` to
+``file``:
+
+::
+
+  large_result_store:
+    type: "file"
+    # base_path: "/var/lib/vantage6/blobs"   # optional, see below
+    # container_name: "results"              # optional subdirectory
+
+When the server is started via ``v6 server start`` the CLI automatically
+bind-mounts the host directory into the container at ``/mnt/blobs`` and
+pins the in-container path with the ``VANTAGE6_BLOB_BASE_PATH``
+environment variable. The mount is created from ``base_path`` if set,
+otherwise from ``<server data dir>/blobs`` (next to where the server
+already keeps its logs and SQLite database). This makes it physically
+impossible for the in-container default to be picked up, so beginners
+get persistence on the host without having to configure any volume
+mounts. The CLI prints the resolved host path at startup.
+
+Blobs are written under a two-character shard derived from the UUID
+identifier (``{base_path}/{uuid[:2]}/{uuid}``) to keep individual
+directories from growing without bound. Writes are atomic: a tempfile
+is ``fsync``-ed and then renamed into place, so readers never observe
+a half-written blob.
+
+.. warning::
+    For multi-replica deployments ``base_path`` must point at a shared
+    filesystem (NFS, Azure Files, …). Replicas using local-only storage
+    will not see each other's blobs.
 
 Developer documentation
 +++++++++++++++++++++++

--- a/docs/features/inter-component/blob_storage.rst
+++ b/docs/features/inter-component/blob_storage.rst
@@ -2,8 +2,8 @@
 
 .. _blob-storage:
 
-Blob Storage
-------------
+Large Result Store
+------------------
 
 The large result store has two backends, selected via the ``type`` field of
 the ``large_result_store`` configuration block:
@@ -22,7 +22,7 @@ To use Azure Blob Storage, the following can be set in the server
 configuration file:
 
 ::
-    
+
   large_result_store:
     type: "azure"
     container_name: test-container
@@ -32,11 +32,11 @@ configuration file:
     storage_account_name: "your-storage-account-name"
 
 The 'test-container' refers to the azure blob container
-(unrelated to Docker containers) in which all blobs are stored. This container should be created in advance manually.
+(unrelated to Docker containers) in which all run data is stored. This container should be created in advance manually.
 Tenant id, client id and client secret are required for authentication (For help on setting up a managed identity,
 see `here <https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory>`__).
 
-For development and testing purposes, `Azurite 
+For development and testing purposes, `Azurite
 <https://github.com/Azure/Azurite>`__ can be used. There are subtle differences
 between the two, so be aware that it will not be completely representative of
 the production environment.
@@ -44,10 +44,10 @@ the production environment.
 
 To use Azurite, a connection string can be configured instead. In the example below,
 the Azurite default connection string is used, with the endpoints adjusted to
-point to a local Azurite instance. 
+point to a local Azurite instance.
 
 ::
-    
+
   large_result_store:
     type: "azure"
     container_name: test-container
@@ -63,61 +63,65 @@ point to a local Azurite instance.
 File backend
 ++++++++++++
 
-To store blobs on the local filesystem instead of Azure, set ``type`` to
-``file``:
+To store run data on the local filesystem instead of Azure, set ``type``
+to ``file``:
 
 ::
 
   large_result_store:
     type: "file"
-    # base_path: "/var/lib/vantage6/blobs"   # optional, see below
-    # container_name: "results"              # optional subdirectory
+    # base_path: "/var/lib/vantage6/run_data"   # optional, see below
+    # container_name: "results"                 # optional subdirectory
 
 When the server is started via ``v6 server start`` the CLI automatically
-bind-mounts the host directory into the container at ``/mnt/blobs`` and
-pins the in-container path with the ``VANTAGE6_BLOB_BASE_PATH``
+bind-mounts the host directory into the container at ``/mnt/run_data``
+and pins the in-container path with the ``VANTAGE6_RUN_DATA_BASE_PATH``
 environment variable. The mount is created from ``base_path`` if set,
-otherwise from ``<server data dir>/blobs`` (next to where the server
+otherwise from ``<server data dir>/run_data`` (next to where the server
 already keeps its logs and SQLite database). This makes it physically
-impossible for the in-container default to be picked up, so beginners
+impossible for the in-container default to be picked up, so users
 get persistence on the host without having to configure any volume
 mounts. The CLI prints the resolved host path at startup.
 
-Blobs are written under a two-character shard derived from the UUID
-identifier (``{base_path}/{uuid[:2]}/{uuid}``) to keep individual
-directories from growing without bound. Writes are atomic: a tempfile
-is ``fsync``-ed and then renamed into place, so readers never observe
-a half-written blob.
+Run-data entries are written under a two-character shard derived from
+the UUID identifier (``{base_path}/{uuid[:2]}/{uuid}``) to keep
+individual directories from growing without bound. Writes are atomic:
+a tempfile is ``fsync``-ed and then renamed into place, so readers
+never observe a half-written entry.
 
 .. warning::
     For multi-replica deployments ``base_path`` must point at a shared
     filesystem (NFS, Azure Files, …). Replicas using local-only storage
-    will not see each other's blobs.
+    will not see each other's run data.
 
 Developer documentation
 +++++++++++++++++++++++
 
-When configured to use blob storage, inputs and results are streamed:
+When configured to use the large result store, inputs and results are
+streamed:
 
-- From the user client, through the server, to blob storage and vice versa
-- From the node client, through the server, to blob storage and vice versa
-- From the algorithm container, through the proxy, server to blob storage and vice versa
+- From the user client, through the server, to the large result store and vice versa
+- From the node client, through the server, to the large result store and vice versa
+- From the algorithm container, through the proxy, server to the large result store and vice versa
 
-Whenever a blob is uploaded, it is stored using a UUID as identifier. This UUID is then used
-as reference in the `input` or `result` field in the database. To ensure backwards compatibility,
-checks are made throughout the code to determine if the run was performed using the relational 
-database, in which case the input or result should be interpreted as is, as opposed to first retrieving
-the data from blob storage.
+Whenever run data is uploaded, it is stored using a UUID as identifier.
+This UUID is then used as reference in the `input` or `result` field in
+the database. To ensure backwards compatibility, checks are made
+throughout the code to determine if the run was performed using the
+relational database, in which case the input or result should be
+interpreted as is, as opposed to first retrieving the data from the
+large result store.
 
-The `blobstream` endpoint on the server enables streaming of large input and result data 
-directly to and from blob storage. This reduces memory usage by never storing the entire input 
-or result in memory at once, and avoids storing large payloads in the database.
+The `blobstream` endpoint on the server enables streaming of large input
+and result data directly to and from the large result store. This
+reduces memory usage by never storing the entire input or result in
+memory at once, and avoids storing large payloads in the database.
 
 Encryption
 ~~~~~~~~~~
 
-Since inputs and results are now uploaded and downloaded separately and are no longer part of 
-a larger JSON object, Base64 encoding is skipped when data is encrypted. The encrypted raw bytes 
+Since inputs and results are now uploaded and downloaded separately and are no longer part of
+a larger JSON object, Base64 encoding is skipped when data is encrypted. The encrypted raw bytes
 can be stored directly.
 Inputs are encrypted before uploading, and results are decrypted after downloading in the node and client.
 Since encryption and decryption for the algorithm container takes place in the proxy, for the algorithm
@@ -127,6 +131,9 @@ input or result into memory at once.
 Database
 ~~~~~~~~
 
-A blob_storage column is added to the `runs` table to indicate whether blob storage and streaming was used for that run.
-This ensures for any run it is clear whether the input or result field should be interpreted directly, or first 
-retrieved. For existing installations, empty values for `blob_storage_used` are assumed to be False.
+A ``blob_storage_used`` column is added to the `runs` table to indicate
+whether the large result store and streaming was used for that run.
+This ensures for any run it is clear whether the input or result field
+should be interpreted directly, or first retrieved. For existing
+installations, empty values for ``blob_storage_used`` are assumed to be
+False.

--- a/docs/features/inter-component/blob_storage.rst
+++ b/docs/features/inter-component/blob_storage.rst
@@ -2,96 +2,80 @@
 
 .. _blob-storage:
 
-Large Result Store
-------------------
+Large Run-Data Store
+--------------------
 
-The large result store has two backends, selected via the ``type`` field of
-the ``large_result_store`` configuration block:
+By default the vantage6 server stores task inputs and results directly
+in the relational database. For deployments that handle large inputs
+or results, the server can be configured to stream them to a separate
+backend instead, identified by a top-level ``large_run_data_store``
+key in the server config:
 
-- ``azure`` — Azure Blob Storage (see below).
-- ``file`` — local filesystem (see :ref:`file-storage-backend`).
+- ``"filesystem"`` — local filesystem (see :ref:`file-run-data-backend`).
+- ``"azure"`` — Azure Blob Storage (see :ref:`azure-run-data-backend`).
 
-If ``type`` is omitted, ``file`` is assumed.
-If ``type`` is unrecognised, the large result store is disabled and a
-warning is logged at startup.
-
-Azure backend
-+++++++++++++
-
-To use Azure Blob Storage, the following can be set in the server
-configuration file:
-
-::
-
-  large_result_store:
-    type: "azure"
-    container_name: test-container
-    tenant_id: "your-tenant-id"
-    client_id: "your-client-id"
-    client_secret: "your-client-secret"
-    storage_account_name: "your-storage-account-name"
-
-The 'test-container' refers to the azure blob container
-(unrelated to Docker containers) in which all run data is stored. This container should be created in advance manually.
-Tenant id, client id and client secret are required for authentication (For help on setting up a managed identity,
-see `here <https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory>`__).
-
-For development and testing purposes, `Azurite
-<https://github.com/Azure/Azurite>`__ can be used. There are subtle differences
-between the two, so be aware that it will not be completely representative of
-the production environment.
-
-
-To use Azurite, a connection string can be configured instead. In the example below,
-the Azurite default connection string is used, with the endpoints adjusted to
-point to a local Azurite instance.
-
-::
-
-  large_result_store:
-    type: "azure"
-    container_name: test-container
-    connection_string: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://172.17.0.1:10000/devstoreaccount1;QueueEndpoint=http://172.17.0.1:10001/devstoreaccount1;"
+If the key is omitted, the relational database is used. If the value
+is not one of the two above the server refuses to start.
 
 .. warning::
-    Note that while it is also possible to use a connection string to connect to Azure Blob Storage,
-    it is not recommended (accountname and accountkey will be stored plainly in the configuration,
-    no automatic rotation, no fine-grained permissions via RBAC and so on).
+   The previous configuration shape used a single ``large_result_store``
+   block with a ``type:`` field. That shape is no longer accepted —
+   the server will raise a ``ValueError`` at startup if it is present.
+   Migrate to the top-level ``large_run_data_store`` string described
+   below.
 
-.. _file-storage-backend:
+.. _file-run-data-backend:
 
-File backend
-++++++++++++
+Filesystem backend
+++++++++++++++++++
 
-To store run data on the local filesystem instead of Azure, set ``type``
-to ``file``:
+To stream run data to the local filesystem, set:
 
 ::
 
-  large_result_store:
-    type: "file"
+  large_run_data_store: "filesystem"
 
-Run data is always written to ``/mnt/run_data`` inside the server 
-container, and where that path points to on the host is decided by
-how you launch the server:
+Run data is always written to ``/mnt/run_data`` inside the server
+container. Where that path points to on the host depends on how the
+server is launched.
 
-- **Under ``v6 server start``**, the CLI automatically bind-mounts
-  ``<server data dir>/run_data`` on the host to ``/mnt/run_data`` in the
-  container. There is no host-path configuration to set; the CLI prints
-  the resolved host path at startup.
-- **Under docker-compose**, you mount the host directory of your choice
-  to ``/mnt/run_data`` in the server container, e.g.
+Under docker-compose
+~~~~~~~~~~~~~~~~~~~~
 
-  ::
+This is the recommended deployment path. Mount the host directory of
+your choice to ``/mnt/run_data`` inside the server container:
 
-    services:
-      server:
-        volumes:
-          - ./my-run-data:/mnt/run_data
+::
+
+  services:
+    server:
+      volumes:
+        - ./my-run-data:/mnt/run_data
+
+.. warning::
+   For multi-replica deployments the host mount target must point at a
+   shared filesystem (NFS, Azure Files, …). Replicas using local-only
+   storage will not see each other's run data.
+
+Under ``v6 server start``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The CLI automatically bind-mounts ``<server data dir>/run_data`` on
+the host to ``/mnt/run_data`` in the container. There is no host-path
+configuration to set; the CLI prints the resolved host path at
+startup. This path is intended for local development; production
+deployments should use the docker-compose path above.
+
+Overriding the in-container path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If for some reason the in-container path ``/mnt/run_data`` is
-unavailable, set ``VANTAGE6_RUN_DATA_BASE_PATH`` on the server container
-to override it (and mount whatever you want at that path instead).
+unavailable, set ``VANTAGE6_RUN_DATA_BASE_PATH`` on the server
+container to override it (and mount whatever you want at that path
+instead).
+
+On-disk layout
+~~~~~~~~~~~~~~
 
 Run-data entries are written under a two-character shard derived from
 the UUID identifier (``{base_path}/{uuid[:2]}/{uuid}``) to keep
@@ -99,33 +83,82 @@ individual directories from growing without bound. Writes are atomic:
 a tempfile is ``fsync``-ed and then renamed into place, so readers
 never observe a half-written entry.
 
+.. _azure-run-data-backend:
+
+Azure backend
++++++++++++++
+
+To stream run data to Azure Blob Storage, set
+``large_run_data_store`` to ``"azure"`` and provide an
+``azure_run_data_store`` block with the credentials:
+
+::
+
+  large_run_data_store: "azure"
+  azure_run_data_store:
+    container_name: test-container
+    tenant_id: "your-tenant-id"
+    client_id: "your-client-id"
+    client_secret: "your-client-secret"
+    storage_account_name: "your-storage-account-name"
+
+The ``test-container`` value above refers to the Azure Blob Storage
+container (unrelated to Docker containers) in which all run data is
+stored. This container must be created in Azure beforehand.
+Tenant id, client id and client secret are required for authentication
+(for help on setting up a managed identity, see
+`Authorize access to blobs using Azure Active Directory
+<https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory>`__).
+
+Development with Azurite
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+For development and testing purposes, `Azurite
+<https://github.com/Azure/Azurite>`__ can be used. There are subtle
+differences between the two, so be aware that it will not be
+completely representative of the production environment.
+
+To use Azurite, a connection string can be configured instead of
+service-principal credentials. The example below uses the Azurite
+default connection string with endpoints adjusted to point at a local
+Azurite instance:
+
+::
+
+  large_run_data_store: "azure"
+  azure_run_data_store:
+    container_name: test-container
+    connection_string: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://172.17.0.1:10000/devstoreaccount1;QueueEndpoint=http://172.17.0.1:10001/devstoreaccount1;"
+
 .. warning::
-    For multi-replica deployments the host mount target must point at a
-    shared filesystem (NFS, Azure Files, …). Replicas using local-only
-    storage will not see each other's run data.
+   Connection strings are not recommended for production: the account
+   name and key are stored in plaintext in the configuration, with no
+   automatic rotation and no fine-grained RBAC permissions.
 
 Developer documentation
 +++++++++++++++++++++++
 
-When configured to use the large result store, inputs and results are
-streamed:
+When configured to use the large run-data store, inputs and results
+are streamed:
 
-- From the user client, through the server, to the large result store and vice versa
-- From the node client, through the server, to the large result store and vice versa
-- From the algorithm container, through the proxy, server to the large result store and vice versa
+- From the user client, through the server, to the run-data store and vice versa
+- From the node client, through the server, to the run-data store and vice versa
+- From the algorithm container, through the proxy and server to the run-data store and vice versa
 
 Whenever run data is uploaded, it is stored using a UUID as identifier.
-This UUID is then used as reference in the `input` or `result` field in
-the database. To ensure backwards compatibility, checks are made
-throughout the code to determine if the run was performed using the
-relational database, in which case the input or result should be
-interpreted as is, as opposed to first retrieving the data from the
-large result store.
+This UUID is then used as the reference in the ``input`` or ``result``
+field in the database. To ensure backwards compatibility, checks are
+made throughout the code to determine whether a run was performed
+using the relational database, in which case the ``input`` or
+``result`` field should be interpreted as-is rather than as a pointer
+into the run-data store.
 
-The `blobstream` endpoint on the server enables streaming of large input
-and result data directly to and from the large result store. This
+The ``/blobstream`` endpoint on the server enables streaming of large
+input and result data directly to and from the run-data store. This
 reduces memory usage by never storing the entire input or result in
-memory at once, and avoids storing large payloads in the database.
+memory at once, and avoids storing large payloads in the database. (The
+endpoint name predates the rename; it is kept for wire-API
+compatibility.)
 
 Encryption
 ~~~~~~~~~~
@@ -141,9 +174,10 @@ input or result into memory at once.
 Database
 ~~~~~~~~
 
-A ``blob_storage_used`` column is added to the `runs` table to indicate
-whether the large result store and streaming was used for that run.
-This ensures for any run it is clear whether the input or result field
-should be interpreted directly, or first retrieved. For existing
-installations, empty values for ``blob_storage_used`` are assumed to be
-False.
+A ``blob_storage_used`` column is present on the ``runs`` table to
+indicate whether the large run-data store and streaming was used for
+that run. This ensures for any run it is clear whether the ``input``
+or ``result`` field should be interpreted directly, or first
+retrieved. For existing installations, empty values for
+``blob_storage_used`` are assumed to be ``False``. (The column name
+predates the rename; it is kept for database-schema compatibility.)

--- a/docs/features/inter-component/blob_storage.rst
+++ b/docs/features/inter-component/blob_storage.rst
@@ -70,18 +70,28 @@ to ``file``:
 
   large_result_store:
     type: "file"
-    # base_path: "/var/lib/vantage6/run_data"   # optional, see below
-    # container_name: "results"                 # optional subdirectory
 
-When the server is started via ``v6 server start`` the CLI automatically
-bind-mounts the host directory into the container at ``/mnt/run_data``
-and pins the in-container path with the ``VANTAGE6_RUN_DATA_BASE_PATH``
-environment variable. The mount is created from ``base_path`` if set,
-otherwise from ``<server data dir>/run_data`` (next to where the server
-already keeps its logs and SQLite database). This makes it physically
-impossible for the in-container default to be picked up, so users
-get persistence on the host without having to configure any volume
-mounts. The CLI prints the resolved host path at startup.
+Run data is always written to ``/mnt/run_data`` inside the server 
+container, and where that path points to on the host is decided by
+how you launch the server:
+
+- **Under ``v6 server start``**, the CLI automatically bind-mounts
+  ``<server data dir>/run_data`` on the host to ``/mnt/run_data`` in the
+  container. There is no host-path configuration to set; the CLI prints
+  the resolved host path at startup.
+- **Under docker-compose**, you mount the host directory of your choice
+  to ``/mnt/run_data`` in the server container, e.g.
+
+  ::
+
+    services:
+      server:
+        volumes:
+          - ./my-run-data:/mnt/run_data
+
+If for some reason the in-container path ``/mnt/run_data`` is
+unavailable, set ``VANTAGE6_RUN_DATA_BASE_PATH`` on the server container
+to override it (and mount whatever you want at that path instead).
 
 Run-data entries are written under a two-character shard derived from
 the UUID identifier (``{base_path}/{uuid[:2]}/{uuid}``) to keep
@@ -90,9 +100,9 @@ a tempfile is ``fsync``-ed and then renamed into place, so readers
 never observe a half-written entry.
 
 .. warning::
-    For multi-replica deployments ``base_path`` must point at a shared
-    filesystem (NFS, Azure Files, …). Replicas using local-only storage
-    will not see each other's run data.
+    For multi-replica deployments the host mount target must point at a
+    shared filesystem (NFS, Azure Files, …). Replicas using local-only
+    storage will not see each other's run data.
 
 Developer documentation
 +++++++++++++++++++++++

--- a/docs/features/inter-component/blob_storage.rst
+++ b/docs/features/inter-component/blob_storage.rst
@@ -74,6 +74,23 @@ unavailable, set ``VANTAGE6_RUN_DATA_BASE_PATH`` on the server
 container to override it (and mount whatever you want at that path
 instead).
 
+The env-var value is used **verbatim** as the storage root — nothing
+is appended to it. Run-data entries land at
+``{VANTAGE6_RUN_DATA_BASE_PATH}/{uuid[:2]}/{uuid}``. For example, with
+``VANTAGE6_RUN_DATA_BASE_PATH=/var/lib/v6/runs`` and a run-data UUID
+of ``abc12345-…``, the file is written to
+``/var/lib/v6/runs/ab/abc12345-…``.
+
+.. warning::
+   This override is intended for the docker-compose path, where you
+   control the bind-mount yourself. Under ``v6 server start`` the CLI
+   always bind-mounts the host's ``<ctx.data_dir>/run_data`` to the
+   container's ``/mnt/run_data`` and does **not** read the env var —
+   setting ``VANTAGE6_RUN_DATA_BASE_PATH`` on a CLI-launched server
+   would make the server read from a path the CLI did not mount, so
+   run data would land inside the ephemeral container filesystem and
+   be lost when the container exits.
+
 On-disk layout
 ~~~~~~~~~~~~~~
 

--- a/docs/server/yaml/server_config.yaml
+++ b/docs/server/yaml/server_config.yaml
@@ -225,12 +225,28 @@ prometheus:
   # Ensure that Prometheus is in the same Docker network as the vantage6 server to resolve the hostname.
   exporter_port: 7603
 
-# Settings for the large result store. By default, the server uses a database to store all inputs and results.
-# Adding this will set Vantage6 to use blob storage rather than the database for both inputs and results.
-large_result_store:
-  # Type of the large result store. Currently, only "azure" is supported.
-  type: "azure"
-  # The name of the Blob Storage container to use for storing large results.
+# Settings for the large run-data store. By default (key absent), the
+# server uses the relational database to store all inputs and results.
+# Set this to enable streaming large inputs and results out of the
+# database instead.
+#
+# Two backends are supported; pick exactly one:
+#
+#   large_run_data_store: "filesystem"
+#     Stores inputs and results on the local filesystem. Under
+#     docker-compose, mount your host directory of choice to
+#     /mnt/run_data inside the server container. Under `v6 server start`,
+#     the CLI bind-mounts <ctx.data_dir>/run_data automatically.
+#
+#   large_run_data_store: "azure"
+#     Stores inputs and results in Azure Blob Storage. Requires the
+#     azure_run_data_store block below.
+large_run_data_store: "azure"
+
+# Required when large_run_data_store is "azure"; ignored otherwise.
+azure_run_data_store:
+  # The name of the Blob Storage container to use. Create this container
+  # in Azure beforehand.
   container_name: test-container
 
   # Use this block for connection string authentication:

--- a/vantage6-common/vantage6/common/client/blob_storage.py
+++ b/vantage6-common/vantage6/common/client/blob_storage.py
@@ -11,7 +11,8 @@ from vantage6.common.client.utils import is_uuid
 
 class BlobStorageMixin:
     """
-    Mixin class to add blob storage functionality to client classes.
+    Mixin class to add large-result-store (run data streaming) functionality
+    to client classes.
     """
 
     def _upload_run_data_to_server(
@@ -51,13 +52,13 @@ class BlobStorageMixin:
                 url, data=chunked_run_data_stream(run_data_bytes), headers=headers
             )
         except requests.RequestException as e:
-            self.log.error(f"Error occurred while uploading blob stream: {e}")
+            self.log.error(f"Error occurred while uploading run data stream: {e}")
             raise requests.RequestException(
-                "Error occurred while uploading blob stream"
+                "Error occurred while uploading run data stream"
             )
 
         if not (200 <= response.status_code < 300):
-            error_msg = f"Failed to upload blob to server: {response.text}"
+            error_msg = f"Failed to upload run data to server: {response.text}"
             self.log.error(error_msg)
             raise RuntimeError(error_msg)
 
@@ -132,9 +133,9 @@ class BlobStorageMixin:
 
     def check_if_blob_store_enabled(self):
         """
-        Check if the blob store is enabled on the server.
-        This function sends a request to the blob stream status endpoint
-        and returns whether the blob store is enabled or not.
+        Check if the large result store is enabled on the server.
+        This function sends a request to the status endpoint and returns
+        whether the large result store is enabled or not.
 
         This is used so that the user does not need to be aware of storage
         used at the server when uploading the first input in the client.
@@ -142,12 +143,12 @@ class BlobStorageMixin:
         Returns
         -------
         bool
-            True if blob store is enabled, False otherwise.
+            True if the large result store is enabled, False otherwise.
 
         Raises
         ------
         requests.RequestException
-            If the request to check blob store status fails.
+            If the request to check the large-result-store status fails.
         """
         base_url = self.generate_path_to("blobstream", False)
         status_url = f"{base_url}/status"
@@ -156,8 +157,8 @@ class BlobStorageMixin:
         response = requests.get(status_url, headers=headers)
         if not response.ok:
             self.log.warning(
-                f"Blob store check failed with status code {response.status_code}. "
-                "Assuming blob store is disabled. Does the server version match this client's version?"
+                f"Large-result-store status check failed with status code {response.status_code}. "
+                "Assuming the large result store is disabled. Does the server version match this client's version?"
             )
             return False
         response_json = response.json()

--- a/vantage6-common/vantage6/common/client/blob_storage.py
+++ b/vantage6-common/vantage6/common/client/blob_storage.py
@@ -4,6 +4,7 @@ import requests
 from vantage6.common.globals import (
     REQUEST_TIMEOUT,
     DEFAULT_CHUNK_SIZE,
+    HTTP_UPLOAD_CHUNK_SIZE,
 )
 from vantage6.common.client.utils import is_uuid
 
@@ -40,7 +41,7 @@ class BlobStorageMixin:
         url = self.generate_path_to("blobstream", False)
 
         def chunked_run_data_stream(
-            run_data: bytes, chunk_size: int = DEFAULT_CHUNK_SIZE
+            run_data: bytes, chunk_size: int = HTTP_UPLOAD_CHUNK_SIZE
         ):
             for i in range(0, len(run_data), chunk_size):
                 yield run_data[i : i + chunk_size]

--- a/vantage6-common/vantage6/common/encryption.py
+++ b/vantage6-common/vantage6/common/encryption.py
@@ -103,7 +103,7 @@ class CryptorBase(metaclass=Singleton):
         skip_base64_encoding_of_msg: bool
             If True, the encrypted message will not be base64 encoded.
             This is useful when the data is already in bytes format and
-            does not need further encoding (e.g., when uploading to blob storage).
+            does not need further encoding (e.g., when uploading to the large result store).
 
         Returns
         -------
@@ -121,14 +121,14 @@ class CryptorBase(metaclass=Singleton):
         data: str | bytes
             The data to decrypt. Can be either a
             string or bytes, depending on whether
-            the data comes from blob storage or not.
+            the data comes from the large result store or not.
 
         Returns
         -------
         bytes
             The decrypted data.
         """
-        # If the data comes from blob storage, decode it to a string first.
+        # If the data comes from the large result store, decode it to a string first.
         if isinstance(data, bytes):
             return self.str_to_bytes(data.decode(STRING_ENCODING))
         elif isinstance(data, str):
@@ -556,7 +556,7 @@ class RSACryptor(CryptorBase):
         skip_base64_encoding_of_msg: bool
             If True, the encrypted message will not be base64 encoded.
             This is useful when the data is already in bytes format and
-            does not need further encoding (e.g., when uploading to blob storage).
+            does not need further encoding (e.g., when uploading to the large result store).
 
         Returns
         -------
@@ -604,7 +604,7 @@ class RSACryptor(CryptorBase):
         ----------
         data: str | bytes
             The data to decrypt. Can be either a string or bytes,
-            depending on whether the data comes from blob storage or not.
+            depending on whether the data comes from the large result store or not.
 
         Returns
         -------
@@ -612,13 +612,13 @@ class RSACryptor(CryptorBase):
             The decrypted data.
         """
         if isinstance(data, bytes):
-            return self.decrypt_bytes_blob_storage(data)
+            return self.decrypt_bytes_run_data(data)
         elif isinstance(data, str):
             return self.decrypt_str_to_bytes(data)
 
-    def decrypt_bytes_blob_storage(self, data: bytes) -> bytes:
+    def decrypt_bytes_run_data(self, data: bytes) -> bytes:
         """
-        Decrypt *bytes* data coming from blob storage.
+        Decrypt *bytes* data coming from the large result store.
         This function expects the data to be in the format:
         <encrypted_key>$<iv>$<encrypted_msg>
 

--- a/vantage6-common/vantage6/common/encryption.py
+++ b/vantage6-common/vantage6/common/encryption.py
@@ -33,7 +33,7 @@ from cryptography.hazmat.primitives.serialization import (
 )
 
 from vantage6.common import Singleton, logger_name, bytes_to_base64s, base64s_to_bytes
-from vantage6.common.globals import DEFAULT_CHUNK_SIZE, STRING_ENCODING
+from vantage6.common.globals import HTTP_UPLOAD_CHUNK_SIZE, STRING_ENCODING
 
 SEPARATOR = "$"
 SHARED_ENCRYPT_KEY_LENGTH = 32
@@ -142,7 +142,7 @@ class CryptorBase(metaclass=Singleton):
         self,
         stream: IO[bytes],
         pubkey_base64s: str = None,
-        chunk_size=DEFAULT_CHUNK_SIZE,
+        chunk_size=HTTP_UPLOAD_CHUNK_SIZE,
     ):
         """
         Base64-encode a stream, yielding encoded chunks.
@@ -185,7 +185,7 @@ class CryptorBase(metaclass=Singleton):
             encoded = base64.b64encode(buffer)
             yield encoded
 
-    def decrypt_stream(self, stream, chunk_size=DEFAULT_CHUNK_SIZE):
+    def decrypt_stream(self, stream, chunk_size=HTTP_UPLOAD_CHUNK_SIZE):
         """
         Decode a base64-encoded stream to bytes, yielding decoded chunks.
         Naming here is confusing (this function does not decrypt),
@@ -700,7 +700,7 @@ class RSACryptor(CryptorBase):
                 pass
         return result
 
-    def _crypt_stream(self, stream, key, iv, chunk_size=DEFAULT_CHUNK_SIZE):
+    def _crypt_stream(self, stream, key, iv, chunk_size=HTTP_UPLOAD_CHUNK_SIZE):
         """
         Encrypt or decrypt a stream using AES-CTR. Since this is a
         symmetric encryption, the same function can be used for both
@@ -739,7 +739,7 @@ class RSACryptor(CryptorBase):
             yield final_chunk
 
     def encrypt_stream(
-        self, stream, pubkey_base64s: str, chunk_size=DEFAULT_CHUNK_SIZE
+        self, stream, pubkey_base64s: str, chunk_size=HTTP_UPLOAD_CHUNK_SIZE
     ):
         """
         Encrypt a stream using hybrid RSA/AES encryption.
@@ -780,7 +780,7 @@ class RSACryptor(CryptorBase):
         yield header_bytes
         yield from self._crypt_stream(stream, shared_key, iv_bytes, chunk_size)
 
-    def decrypt_stream(self, stream, chunk_size=DEFAULT_CHUNK_SIZE):
+    def decrypt_stream(self, stream, chunk_size=HTTP_UPLOAD_CHUNK_SIZE):
         """
         Decrypt a stream that was encrypted using hybrid RSA/AES encryption.
 

--- a/vantage6-common/vantage6/common/globals.py
+++ b/vantage6-common/vantage6/common/globals.py
@@ -62,7 +62,7 @@ REQUEST_TIMEOUT = 300
 # Default chunk size for streaming inputs and results
 DEFAULT_CHUNK_SIZE = 1024 * 1024  # 1MB
 
-# Wire-level chunk size for HTTP Transfer-Encoding: chunked uploads of blobs
+# Wire-level chunk size for HTTP Transfer-Encoding: chunked uploads of run data
 # and encrypted streams. Must stay well below ``MAX_CHUNKED_INPUT_PART`` —
 # a single chunk at or above the server-side limit makes
 # ``uwsgi.chunked_read`` raise ``IOError: unable to receive chunked part``.

--- a/vantage6-common/vantage6/common/globals.py
+++ b/vantage6-common/vantage6/common/globals.py
@@ -62,6 +62,22 @@ REQUEST_TIMEOUT = 300
 # Default chunk size for streaming inputs and results
 DEFAULT_CHUNK_SIZE = 1024 * 1024  # 1MB
 
+# Wire-level chunk size for HTTP Transfer-Encoding: chunked uploads of blobs
+# and encrypted streams. Must stay well below ``MAX_CHUNKED_INPUT_PART`` —
+# a single chunk at or above the server-side limit makes
+# ``uwsgi.chunked_read`` raise ``IOError: unable to receive chunked part``.
+HTTP_UPLOAD_CHUNK_SIZE = 256 * 1024  # 256 KiB
+
+# Server-side cap (in bytes) on the size of a single chunked-input part,
+# passed to uwsgi as ``--chunked-input-limit``. Deliberately much larger
+# than ``HTTP_UPLOAD_CHUNK_SIZE`` so the friendly client always has
+# headroom, and small enough to reject obviously hostile bodies before
+# they consume server memory. Intentionally not the same constant as
+# ``HTTP_UPLOAD_CHUNK_SIZE``: client and server play opposite roles
+# (size we send vs. size we refuse above), and equality would remove the
+# safety margin a chunked-input limit is supposed to provide.
+MAX_CHUNKED_INPUT_PART = 16 * 1024 * 1024  # 16 MiB
+
 
 class InstanceType(str, Enum):
     """The types of instances that can be created."""

--- a/vantage6-node/vantage6/node/proxy_server.py
+++ b/vantage6-node/vantage6/node/proxy_server.py
@@ -20,7 +20,7 @@ from flask import Flask, request, stream_with_context, Response as FlaskResponse
 from vantage6.common import bytes_to_base64s, base64s_to_bytes, logger_name
 from vantage6.common.client.node_client import NodeClient
 from vantage6.common.client.utils import is_uuid
-from vantage6.common.globals import STRING_ENCODING
+from vantage6.common.globals import HTTP_UPLOAD_CHUNK_SIZE, STRING_ENCODING
 
 
 # Initialize FLASK
@@ -510,7 +510,9 @@ def stream_handler_post() -> FlaskResponse:
     url = f"{server_url}/blobstream"
     log.debug("Making proxied POST request to %s", url)
 
-    encrypted_stream = client.cryptor.encrypt_stream(request.stream, pubkey_base64)
+    encrypted_stream = client.cryptor.encrypt_stream(
+        request.stream, pubkey_base64, chunk_size=HTTP_UPLOAD_CHUNK_SIZE
+    )
     # Stream the data to the server while encrypting it.
     # This is done to avoid loading the entire content into memory.
     # The encrypted stream is a generator that yields chunks of encrypted data.

--- a/vantage6-server/server.sh
+++ b/vantage6-server/server.sh
@@ -14,6 +14,7 @@ uwsgi \
     --gevent 1000 \
     --http-websockets \
     --http-chunked-input \
+    --chunked-input-limit $((16 * 1024 * 1024)) \
     --http-keepalive \
     --post-buffering 0 \
     --master --callable app --disable-logging \

--- a/vantage6-server/tests_server/test_cleanup.py
+++ b/vantage6-server/tests_server/test_cleanup.py
@@ -54,9 +54,9 @@ class TestCleanupRunsIsolated(unittest.TestCase):
         self.assertIsNotNone(run.cleanup_at)
 
     @patch(
-        "vantage6.server.service.azure_storage_service.AzureStorageService.delete_blob"
+        "vantage6.server.service.azure_storage_service.AzureStorageService.delete_run_data"
     )
-    def test_cleanup_completed_old_blob(self, mock_delete_blob):
+    def test_cleanup_completed_old_run_data(self, mock_delete_run_data):
         task = Task(
             name="test-task",
             description="Test task for cleanup",
@@ -91,9 +91,9 @@ class TestCleanupRunsIsolated(unittest.TestCase):
         self.session.refresh(run)
 
         expected_calls = [call(self.uuid), call("input")]
-        mock_delete_blob.assert_has_calls(expected_calls, any_order=False)
+        mock_delete_run_data.assert_has_calls(expected_calls, any_order=False)
 
-    def test_cleanup_completed_old_blob_file_backend(self):
+    def test_cleanup_completed_old_run_data_file_backend(self):
         task = Task(
             name="test-task",
             description="Test task for cleanup",
@@ -119,8 +119,8 @@ class TestCleanupRunsIsolated(unittest.TestCase):
             from vantage6.server.service.file_storage_service import FileStorageService
 
             adapter = FileStorageService({"base_path": base_dir})
-            adapter.store_blob(result_uuid, b"result-bytes")
-            adapter.store_blob(input_uuid, b"input-bytes")
+            adapter.store_run_data(result_uuid, b"result-bytes")
+            adapter.store_run_data(input_uuid, b"input-bytes")
             result_path = Path(base_dir) / result_uuid[:2] / result_uuid
             input_path = Path(base_dir) / input_uuid[:2] / input_uuid
             assert result_path.is_file()

--- a/vantage6-server/tests_server/test_cleanup.py
+++ b/vantage6-server/tests_server/test_cleanup.py
@@ -77,8 +77,8 @@ class TestCleanupRunsIsolated(unittest.TestCase):
 
         config = {
             "runs_data_cleanup_days": 30,
-            "large_result_store": {
-                "type": "azure",
+            "large_run_data_store": "azure",
+            "azure_run_data_store": {
                 "container_name": "test-container",
                 "connection_string": "DefaultEndpointsProtocol=https;AccountName=dummyname;AccountKey=dummykey",
             },
@@ -131,7 +131,7 @@ class TestCleanupRunsIsolated(unittest.TestCase):
 
             config = {
                 "runs_data_cleanup_days": 30,
-                "large_result_store": {"type": "file"},
+                "large_run_data_store": "filesystem",
             }
 
             self.session.add(run)

--- a/vantage6-server/tests_server/test_cleanup.py
+++ b/vantage6-server/tests_server/test_cleanup.py
@@ -116,9 +116,12 @@ class TestCleanupRunsIsolated(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory() as base_dir:
-            from vantage6.server.service.file_storage_service import FileStorageService
+            from vantage6.server.service.file_storage_service import (
+                RUN_DATA_BASE_PATH_ENV_VAR,
+                FileStorageService,
+            )
 
-            adapter = FileStorageService({"base_path": base_dir})
+            adapter = FileStorageService({}, base_path=base_dir)
             adapter.store_run_data(result_uuid, b"result-bytes")
             adapter.store_run_data(input_uuid, b"input-bytes")
             result_path = Path(base_dir) / result_uuid[:2] / result_uuid
@@ -128,13 +131,19 @@ class TestCleanupRunsIsolated(unittest.TestCase):
 
             config = {
                 "runs_data_cleanup_days": 30,
-                "large_result_store": {"type": "file", "base_path": base_dir},
+                "large_result_store": {"type": "file"},
             }
 
             self.session.add(run)
             self.session.commit()
 
-            cleanup.cleanup_runs_data(config, include_input=True)
+            # The cleanup controller builds its own adapter via the
+            # factory, which reads the env var — point it at the same
+            # tempdir so it deletes the files we just wrote.
+            with patch.dict(
+                "os.environ", {RUN_DATA_BASE_PATH_ENV_VAR: base_dir}
+            ):
+                cleanup.cleanup_runs_data(config, include_input=True)
             self.session.refresh(run)
 
             assert not result_path.exists()

--- a/vantage6-server/tests_server/test_cleanup.py
+++ b/vantage6-server/tests_server/test_cleanup.py
@@ -1,6 +1,8 @@
+import tempfile
 import unittest
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 import uuid
 from unittest.mock import patch, call
 
@@ -90,6 +92,55 @@ class TestCleanupRunsIsolated(unittest.TestCase):
 
         expected_calls = [call(self.uuid), call("input")]
         mock_delete_blob.assert_has_calls(expected_calls, any_order=False)
+
+    def test_cleanup_completed_old_blob_file_backend(self):
+        task = Task(
+            name="test-task",
+            description="Test task for cleanup",
+            image="test-image:latest",
+        )
+        self.session.add(task)
+        self.session.commit()
+
+        result_uuid = str(uuid.uuid4())
+        input_uuid = str(uuid.uuid4())
+
+        run = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=31),
+            result=result_uuid,
+            input=input_uuid,
+            log="log should be preserved",
+            status=TaskStatus.COMPLETED,
+            task=task,
+            blob_storage_used=True,
+        )
+
+        with tempfile.TemporaryDirectory() as base_dir:
+            from vantage6.server.service.file_storage_service import FileStorageService
+
+            adapter = FileStorageService({"base_path": base_dir})
+            adapter.store_blob(result_uuid, b"result-bytes")
+            adapter.store_blob(input_uuid, b"input-bytes")
+            result_path = Path(base_dir) / result_uuid[:2] / result_uuid
+            input_path = Path(base_dir) / input_uuid[:2] / input_uuid
+            assert result_path.is_file()
+            assert input_path.is_file()
+
+            config = {
+                "runs_data_cleanup_days": 30,
+                "large_result_store": {"type": "file", "base_path": base_dir},
+            }
+
+            self.session.add(run)
+            self.session.commit()
+
+            cleanup.cleanup_runs_data(config, include_input=True)
+            self.session.refresh(run)
+
+            assert not result_path.exists()
+            assert not input_path.exists()
+            assert run.result == ""
+            assert run.input == ""
 
     def test_no_cleanup_recent_completed_run(self):
         # Ineligible: completed, but not old enough

--- a/vantage6-server/tests_server/test_file_storage_service.py
+++ b/vantage6-server/tests_server/test_file_storage_service.py
@@ -14,7 +14,10 @@ from vantage6.server.service.file_storage_service import (
     RUN_DATA_BASE_PATH_ENV_VAR,
     FileStorageService,
 )
-from vantage6.server.service.storage_adapter import build_storage_adapter
+from vantage6.server.service.storage_adapter import (
+    RunDataNotFoundError,
+    build_storage_adapter,
+)
 
 
 def _uuid() -> str:
@@ -96,11 +99,11 @@ class TestFileStorageService(unittest.TestCase):
         self.assertEqual(adapter.base_path, self.tmp_path.resolve())
 
     def test_stream_missing_run_data_raises(self) -> None:
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(RunDataNotFoundError):
             self.adapter.stream_run_data(_uuid())
 
     def test_get_missing_run_data_raises(self) -> None:
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(RunDataNotFoundError):
             self.adapter.get_run_data(_uuid())
 
 

--- a/vantage6-server/tests_server/test_file_storage_service.py
+++ b/vantage6-server/tests_server/test_file_storage_service.py
@@ -105,10 +105,15 @@ class TestFileStorageService(unittest.TestCase):
 
 
 class TestStorageAdapterFactory(unittest.TestCase):
+    def test_factory_returns_none_when_unset(self) -> None:
+        self.assertIsNone(build_storage_adapter({}))
+
     def test_factory_uses_env_var_for_base_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             with patch.dict(os.environ, {RUN_DATA_BASE_PATH_ENV_VAR: tmp}):
-                adapter = build_storage_adapter({"type": "file"})
+                adapter = build_storage_adapter(
+                    {"large_run_data_store": "filesystem"}
+                )
             self.assertIsInstance(adapter, FileStorageService)
             self.assertEqual(adapter.base_path, Path(tmp).resolve())
 
@@ -118,12 +123,28 @@ class TestStorageAdapterFactory(unittest.TestCase):
             with patch(
                 "vantage6.server.service.file_storage_service.Path.mkdir"
             ) as mock_mkdir:
-                adapter = build_storage_adapter({"type": "file"})
+                adapter = build_storage_adapter(
+                    {"large_run_data_store": "filesystem"}
+                )
         self.assertIsInstance(adapter, FileStorageService)
         self.assertEqual(
             adapter.base_path, Path(DEFAULT_RUN_DATA_BASE_PATH).resolve()
         )
         mock_mkdir.assert_called()
+
+    def test_factory_rejects_deprecated_large_result_store_key(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            build_storage_adapter({"large_result_store": {"type": "file"}})
+        self.assertIn("large_result_store", str(cm.exception))
+
+    def test_factory_rejects_unknown_store_type(self) -> None:
+        with self.assertRaises(ValueError):
+            build_storage_adapter({"large_run_data_store": "s3"})
+
+    def test_factory_rejects_azure_without_block(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            build_storage_adapter({"large_run_data_store": "azure"})
+        self.assertIn("azure_run_data_store", str(cm.exception))
 
 
 if __name__ == "__main__":

--- a/vantage6-server/tests_server/test_file_storage_service.py
+++ b/vantage6-server/tests_server/test_file_storage_service.py
@@ -1,0 +1,136 @@
+"""Tests for the local-filesystem large-result-store backend."""
+
+import io
+import os
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from vantage6.common.globals import DEFAULT_CHUNK_SIZE
+from vantage6.server.service.file_storage_service import (
+    BLOB_BASE_PATH_ENV_VAR,
+    FileStorageService,
+)
+
+
+@pytest.fixture
+def adapter(tmp_path: Path) -> FileStorageService:
+    return FileStorageService({"base_path": str(tmp_path)})
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def test_bytes_roundtrip(adapter: FileStorageService) -> None:
+    name = _uuid()
+    payload = b"hello world"
+    adapter.store_blob(name, payload)
+    assert adapter.get_blob(name) == payload
+
+
+def test_stream_roundtrip(adapter: FileStorageService) -> None:
+    name = _uuid()
+    # Span several read chunks with a non-aligned tail to exercise partial reads.
+    payload = b"x" * (3 * DEFAULT_CHUNK_SIZE + 17)
+    adapter.store_blob(name, payload)
+
+    chunks = list(adapter.stream_blob(name).chunks())
+    assert b"".join(chunks) == payload
+    assert all(c for c in chunks)
+
+
+def test_iostream_roundtrip(adapter: FileStorageService) -> None:
+    name = _uuid()
+    # Span several write chunks with a non-aligned tail to exercise partial writes.
+    payload = os.urandom(3 * DEFAULT_CHUNK_SIZE + 17)
+    adapter.store_blob(name, io.BytesIO(payload))
+    assert adapter.get_blob(name) == payload
+
+
+def test_sharded_layout(adapter: FileStorageService, tmp_path: Path) -> None:
+    name = _uuid()
+    adapter.store_blob(name, b"x")
+    assert (tmp_path / name[:2] / name).is_file()
+
+
+def test_container_subdir(tmp_path: Path) -> None:
+    adapter = FileStorageService(
+        {"base_path": str(tmp_path), "container_name": "results"}
+    )
+    name = _uuid()
+    adapter.store_blob(name, b"x")
+    assert (tmp_path / "results" / name[:2] / name).is_file()
+
+
+def test_delete_idempotent(adapter: FileStorageService) -> None:
+    name = _uuid()
+    adapter.delete_blob(name)  # missing — should not raise
+    adapter.store_blob(name, b"x")
+    adapter.delete_blob(name)
+    assert not (adapter.base_path / name[:2] / name).exists()
+    adapter.delete_blob(name)  # idempotent after delete
+
+
+def test_atomic_write_crash_safety(adapter: FileStorageService) -> None:
+    name = _uuid()
+    with patch(
+        "vantage6.server.service.file_storage_service.os.replace",
+        side_effect=OSError("simulated crash"),
+    ):
+        with pytest.raises(RuntimeError):
+            adapter.store_blob(name, b"payload")
+
+    shard = adapter.base_path / name[:2]
+    target = shard / name
+    assert not target.exists()
+    if shard.exists():
+        assert not any(p.name.startswith(".tmp-") for p in shard.iterdir())
+
+
+def test_path_traversal_rejected(adapter: FileStorageService) -> None:
+    with pytest.raises(ValueError):
+        adapter.store_blob("../etc/passwd", b"x")
+    with pytest.raises(ValueError):
+        adapter.store_blob("a/b", b"x")
+    with pytest.raises(ValueError):
+        adapter.get_blob("")
+
+
+def test_missing_base_path_rejected() -> None:
+    with pytest.raises(ValueError):
+        FileStorageService({})
+
+
+def test_env_var_overrides_config_base_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_path = tmp_path / "env-dir"
+    config_path = tmp_path / "config-dir"
+    monkeypatch.setenv(BLOB_BASE_PATH_ENV_VAR, str(env_path))
+
+    adapter = FileStorageService({"base_path": str(config_path)})
+
+    assert adapter.base_path == env_path.resolve()
+    assert env_path.is_dir()
+    assert not config_path.exists()
+
+
+def test_env_var_used_when_config_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(BLOB_BASE_PATH_ENV_VAR, str(tmp_path))
+    adapter = FileStorageService({})
+    assert adapter.base_path == tmp_path.resolve()
+
+
+def test_stream_missing_blob_raises(adapter: FileStorageService) -> None:
+    with pytest.raises(FileNotFoundError):
+        adapter.stream_blob(_uuid())
+
+
+def test_get_missing_blob_raises(adapter: FileStorageService) -> None:
+    with pytest.raises(FileNotFoundError):
+        adapter.get_blob(_uuid())

--- a/vantage6-server/tests_server/test_file_storage_service.py
+++ b/vantage6-server/tests_server/test_file_storage_service.py
@@ -2,135 +2,129 @@
 
 import io
 import os
+import tempfile
+import unittest
 import uuid
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from vantage6.common.globals import DEFAULT_CHUNK_SIZE
 from vantage6.server.service.file_storage_service import (
+    DEFAULT_RUN_DATA_BASE_PATH,
     RUN_DATA_BASE_PATH_ENV_VAR,
     FileStorageService,
 )
-
-
-@pytest.fixture
-def adapter(tmp_path: Path) -> FileStorageService:
-    return FileStorageService({"base_path": str(tmp_path)})
+from vantage6.server.service.storage_adapter import build_storage_adapter
 
 
 def _uuid() -> str:
     return str(uuid.uuid4())
 
 
-def test_bytes_roundtrip(adapter: FileStorageService) -> None:
-    name = _uuid()
-    payload = b"hello world"
-    adapter.store_run_data(name, payload)
-    assert adapter.get_run_data(name) == payload
+class TestFileStorageService(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmp.name)
+        self.adapter = FileStorageService({}, base_path=self.tmp_path)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_bytes_roundtrip(self) -> None:
+        name = _uuid()
+        payload = b"hello world"
+        self.adapter.store_run_data(name, payload)
+        self.assertEqual(self.adapter.get_run_data(name), payload)
+
+    def test_stream_roundtrip(self) -> None:
+        name = _uuid()
+        # Span several read chunks with a non-aligned tail to exercise partial reads.
+        payload = b"x" * (3 * DEFAULT_CHUNK_SIZE + 17)
+        self.adapter.store_run_data(name, payload)
+
+        chunks = list(self.adapter.stream_run_data(name).chunks())
+        self.assertEqual(b"".join(chunks), payload)
+        self.assertTrue(all(c for c in chunks))
+
+    def test_iostream_roundtrip(self) -> None:
+        name = _uuid()
+        # Span several write chunks with a non-aligned tail to exercise partial writes.
+        payload = os.urandom(3 * DEFAULT_CHUNK_SIZE + 17)
+        self.adapter.store_run_data(name, io.BytesIO(payload))
+        self.assertEqual(self.adapter.get_run_data(name), payload)
+
+    def test_sharded_layout(self) -> None:
+        name = _uuid()
+        self.adapter.store_run_data(name, b"x")
+        self.assertTrue((self.tmp_path / name[:2] / name).is_file())
+
+    def test_delete_idempotent(self) -> None:
+        name = _uuid()
+        self.adapter.delete_run_data(name)  # missing — should not raise
+        self.adapter.store_run_data(name, b"x")
+        self.adapter.delete_run_data(name)
+        self.assertFalse((self.adapter.base_path / name[:2] / name).exists())
+        self.adapter.delete_run_data(name)  # idempotent after delete
+
+    def test_atomic_write_crash_safety(self) -> None:
+        name = _uuid()
+        with patch(
+            "vantage6.server.service.file_storage_service.os.replace",
+            side_effect=OSError("simulated crash"),
+        ):
+            with self.assertRaises(RuntimeError):
+                self.adapter.store_run_data(name, b"payload")
+
+        shard = self.adapter.base_path / name[:2]
+        target = shard / name
+        self.assertFalse(target.exists())
+        if shard.exists():
+            self.assertFalse(
+                any(p.name.startswith(".tmp-") for p in shard.iterdir())
+            )
+
+    def test_path_traversal_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self.adapter.store_run_data("../etc/passwd", b"x")
+        with self.assertRaises(ValueError):
+            self.adapter.store_run_data("a/b", b"x")
+        with self.assertRaises(ValueError):
+            self.adapter.get_run_data("")
+
+    def test_base_path_resolved(self) -> None:
+        adapter = FileStorageService({}, base_path=self.tmp_path)
+        self.assertEqual(adapter.base_path, self.tmp_path.resolve())
+
+    def test_stream_missing_run_data_raises(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            self.adapter.stream_run_data(_uuid())
+
+    def test_get_missing_run_data_raises(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            self.adapter.get_run_data(_uuid())
 
 
-def test_stream_roundtrip(adapter: FileStorageService) -> None:
-    name = _uuid()
-    # Span several read chunks with a non-aligned tail to exercise partial reads.
-    payload = b"x" * (3 * DEFAULT_CHUNK_SIZE + 17)
-    adapter.store_run_data(name, payload)
+class TestStorageAdapterFactory(unittest.TestCase):
+    def test_factory_uses_env_var_for_base_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {RUN_DATA_BASE_PATH_ENV_VAR: tmp}):
+                adapter = build_storage_adapter({"type": "file"})
+            self.assertIsInstance(adapter, FileStorageService)
+            self.assertEqual(adapter.base_path, Path(tmp).resolve())
 
-    chunks = list(adapter.stream_run_data(name).chunks())
-    assert b"".join(chunks) == payload
-    assert all(c for c in chunks)
-
-
-def test_iostream_roundtrip(adapter: FileStorageService) -> None:
-    name = _uuid()
-    # Span several write chunks with a non-aligned tail to exercise partial writes.
-    payload = os.urandom(3 * DEFAULT_CHUNK_SIZE + 17)
-    adapter.store_run_data(name, io.BytesIO(payload))
-    assert adapter.get_run_data(name) == payload
-
-
-def test_sharded_layout(adapter: FileStorageService, tmp_path: Path) -> None:
-    name = _uuid()
-    adapter.store_run_data(name, b"x")
-    assert (tmp_path / name[:2] / name).is_file()
+    def test_factory_falls_back_to_default_when_env_unset(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != RUN_DATA_BASE_PATH_ENV_VAR}
+        with patch.dict(os.environ, env, clear=True):
+            with patch(
+                "vantage6.server.service.file_storage_service.Path.mkdir"
+            ) as mock_mkdir:
+                adapter = build_storage_adapter({"type": "file"})
+        self.assertIsInstance(adapter, FileStorageService)
+        self.assertEqual(
+            adapter.base_path, Path(DEFAULT_RUN_DATA_BASE_PATH).resolve()
+        )
+        mock_mkdir.assert_called()
 
 
-def test_container_subdir(tmp_path: Path) -> None:
-    adapter = FileStorageService(
-        {"base_path": str(tmp_path), "container_name": "results"}
-    )
-    name = _uuid()
-    adapter.store_run_data(name, b"x")
-    assert (tmp_path / "results" / name[:2] / name).is_file()
-
-
-def test_delete_idempotent(adapter: FileStorageService) -> None:
-    name = _uuid()
-    adapter.delete_run_data(name)  # missing — should not raise
-    adapter.store_run_data(name, b"x")
-    adapter.delete_run_data(name)
-    assert not (adapter.base_path / name[:2] / name).exists()
-    adapter.delete_run_data(name)  # idempotent after delete
-
-
-def test_atomic_write_crash_safety(adapter: FileStorageService) -> None:
-    name = _uuid()
-    with patch(
-        "vantage6.server.service.file_storage_service.os.replace",
-        side_effect=OSError("simulated crash"),
-    ):
-        with pytest.raises(RuntimeError):
-            adapter.store_run_data(name, b"payload")
-
-    shard = adapter.base_path / name[:2]
-    target = shard / name
-    assert not target.exists()
-    if shard.exists():
-        assert not any(p.name.startswith(".tmp-") for p in shard.iterdir())
-
-
-def test_path_traversal_rejected(adapter: FileStorageService) -> None:
-    with pytest.raises(ValueError):
-        adapter.store_run_data("../etc/passwd", b"x")
-    with pytest.raises(ValueError):
-        adapter.store_run_data("a/b", b"x")
-    with pytest.raises(ValueError):
-        adapter.get_run_data("")
-
-
-def test_missing_base_path_rejected() -> None:
-    with pytest.raises(ValueError):
-        FileStorageService({})
-
-
-def test_env_var_overrides_config_base_path(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    env_path = tmp_path / "env-dir"
-    config_path = tmp_path / "config-dir"
-    monkeypatch.setenv(RUN_DATA_BASE_PATH_ENV_VAR, str(env_path))
-
-    adapter = FileStorageService({"base_path": str(config_path)})
-
-    assert adapter.base_path == env_path.resolve()
-    assert env_path.is_dir()
-    assert not config_path.exists()
-
-
-def test_env_var_used_when_config_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv(RUN_DATA_BASE_PATH_ENV_VAR, str(tmp_path))
-    adapter = FileStorageService({})
-    assert adapter.base_path == tmp_path.resolve()
-
-
-def test_stream_missing_run_data_raises(adapter: FileStorageService) -> None:
-    with pytest.raises(FileNotFoundError):
-        adapter.stream_run_data(_uuid())
-
-
-def test_get_missing_run_data_raises(adapter: FileStorageService) -> None:
-    with pytest.raises(FileNotFoundError):
-        adapter.get_run_data(_uuid())
+if __name__ == "__main__":
+    unittest.main()

--- a/vantage6-server/tests_server/test_file_storage_service.py
+++ b/vantage6-server/tests_server/test_file_storage_service.py
@@ -10,7 +10,7 @@ import pytest
 
 from vantage6.common.globals import DEFAULT_CHUNK_SIZE
 from vantage6.server.service.file_storage_service import (
-    BLOB_BASE_PATH_ENV_VAR,
+    RUN_DATA_BASE_PATH_ENV_VAR,
     FileStorageService,
 )
 
@@ -27,17 +27,17 @@ def _uuid() -> str:
 def test_bytes_roundtrip(adapter: FileStorageService) -> None:
     name = _uuid()
     payload = b"hello world"
-    adapter.store_blob(name, payload)
-    assert adapter.get_blob(name) == payload
+    adapter.store_run_data(name, payload)
+    assert adapter.get_run_data(name) == payload
 
 
 def test_stream_roundtrip(adapter: FileStorageService) -> None:
     name = _uuid()
     # Span several read chunks with a non-aligned tail to exercise partial reads.
     payload = b"x" * (3 * DEFAULT_CHUNK_SIZE + 17)
-    adapter.store_blob(name, payload)
+    adapter.store_run_data(name, payload)
 
-    chunks = list(adapter.stream_blob(name).chunks())
+    chunks = list(adapter.stream_run_data(name).chunks())
     assert b"".join(chunks) == payload
     assert all(c for c in chunks)
 
@@ -46,13 +46,13 @@ def test_iostream_roundtrip(adapter: FileStorageService) -> None:
     name = _uuid()
     # Span several write chunks with a non-aligned tail to exercise partial writes.
     payload = os.urandom(3 * DEFAULT_CHUNK_SIZE + 17)
-    adapter.store_blob(name, io.BytesIO(payload))
-    assert adapter.get_blob(name) == payload
+    adapter.store_run_data(name, io.BytesIO(payload))
+    assert adapter.get_run_data(name) == payload
 
 
 def test_sharded_layout(adapter: FileStorageService, tmp_path: Path) -> None:
     name = _uuid()
-    adapter.store_blob(name, b"x")
+    adapter.store_run_data(name, b"x")
     assert (tmp_path / name[:2] / name).is_file()
 
 
@@ -61,17 +61,17 @@ def test_container_subdir(tmp_path: Path) -> None:
         {"base_path": str(tmp_path), "container_name": "results"}
     )
     name = _uuid()
-    adapter.store_blob(name, b"x")
+    adapter.store_run_data(name, b"x")
     assert (tmp_path / "results" / name[:2] / name).is_file()
 
 
 def test_delete_idempotent(adapter: FileStorageService) -> None:
     name = _uuid()
-    adapter.delete_blob(name)  # missing — should not raise
-    adapter.store_blob(name, b"x")
-    adapter.delete_blob(name)
+    adapter.delete_run_data(name)  # missing — should not raise
+    adapter.store_run_data(name, b"x")
+    adapter.delete_run_data(name)
     assert not (adapter.base_path / name[:2] / name).exists()
-    adapter.delete_blob(name)  # idempotent after delete
+    adapter.delete_run_data(name)  # idempotent after delete
 
 
 def test_atomic_write_crash_safety(adapter: FileStorageService) -> None:
@@ -81,7 +81,7 @@ def test_atomic_write_crash_safety(adapter: FileStorageService) -> None:
         side_effect=OSError("simulated crash"),
     ):
         with pytest.raises(RuntimeError):
-            adapter.store_blob(name, b"payload")
+            adapter.store_run_data(name, b"payload")
 
     shard = adapter.base_path / name[:2]
     target = shard / name
@@ -92,11 +92,11 @@ def test_atomic_write_crash_safety(adapter: FileStorageService) -> None:
 
 def test_path_traversal_rejected(adapter: FileStorageService) -> None:
     with pytest.raises(ValueError):
-        adapter.store_blob("../etc/passwd", b"x")
+        adapter.store_run_data("../etc/passwd", b"x")
     with pytest.raises(ValueError):
-        adapter.store_blob("a/b", b"x")
+        adapter.store_run_data("a/b", b"x")
     with pytest.raises(ValueError):
-        adapter.get_blob("")
+        adapter.get_run_data("")
 
 
 def test_missing_base_path_rejected() -> None:
@@ -109,7 +109,7 @@ def test_env_var_overrides_config_base_path(
 ) -> None:
     env_path = tmp_path / "env-dir"
     config_path = tmp_path / "config-dir"
-    monkeypatch.setenv(BLOB_BASE_PATH_ENV_VAR, str(env_path))
+    monkeypatch.setenv(RUN_DATA_BASE_PATH_ENV_VAR, str(env_path))
 
     adapter = FileStorageService({"base_path": str(config_path)})
 
@@ -121,16 +121,16 @@ def test_env_var_overrides_config_base_path(
 def test_env_var_used_when_config_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv(BLOB_BASE_PATH_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv(RUN_DATA_BASE_PATH_ENV_VAR, str(tmp_path))
     adapter = FileStorageService({})
     assert adapter.base_path == tmp_path.resolve()
 
 
-def test_stream_missing_blob_raises(adapter: FileStorageService) -> None:
+def test_stream_missing_run_data_raises(adapter: FileStorageService) -> None:
     with pytest.raises(FileNotFoundError):
-        adapter.stream_blob(_uuid())
+        adapter.stream_run_data(_uuid())
 
 
-def test_get_missing_blob_raises(adapter: FileStorageService) -> None:
+def test_get_missing_run_data_raises(adapter: FileStorageService) -> None:
     with pytest.raises(FileNotFoundError):
-        adapter.get_blob(_uuid())
+        adapter.get_run_data(_uuid())

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -80,7 +80,7 @@ from vantage6.server.websockets import DefaultSocketNamespace
 from vantage6.server.default_roles import get_default_roles, DefaultRole
 from vantage6.server.hashedpassword import HashedPassword
 from vantage6.server.controller import cleanup
-from vantage6.server.service.azure_storage_service import AzureStorageService
+from vantage6.server.service.storage_adapter import build_storage_adapter
 
 
 # make sure the version is available
@@ -205,19 +205,21 @@ class ServerApp:
     def setup_large_result_store(self):
         """
         Setup the large result store for storing large results.
-        If configured, inputs and results will be stored in blob Storage.
+        If configured, inputs and results will be stored in the selected
+        backend (Azure Blob Storage or local filesystem).
         """
 
-        self.storage_adapter = None
         large_result_config = self.ctx.config.get("large_result_store", {})
         if not large_result_config:
             log.info(
                 "No large result store configured, using relational database for input and result storage"
             )
+            self.storage_adapter = None
             return
 
-        log.info("Using Azure Blob Storage as large result store")
-        self.storage_adapter = AzureStorageService(config=large_result_config)
+        store_type = large_result_config.get("type", "azure")
+        log.info("Using %r backend as large result store", store_type)
+        self.storage_adapter = build_storage_adapter(large_result_config)
 
     @staticmethod
     def _warn_if_cors_regex(origins: str | list[str]) -> None:

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -204,22 +204,21 @@ class ServerApp:
 
     def setup_large_result_store(self):
         """
-        Setup the large result store for storing large results.
+        Setup the large run-data store for storing large inputs and results.
         If configured, inputs and results will be stored in the selected
-        backend (Azure Blob Storage or local filesystem).
+        backend (Azure Blob Storage or local filesystem); otherwise the
+        relational database is used.
         """
-
-        large_result_config = self.ctx.config.get("large_result_store", {})
-        if not large_result_config:
+        store_type = self.ctx.config.get("large_run_data_store")
+        if store_type is None:
             log.info(
-                "No large result store configured, using relational database for input and result storage"
+                "No large run-data store configured, using relational database for input and result storage"
             )
             self.storage_adapter = None
             return
 
-        store_type = large_result_config.get("type", "azure")
-        log.info("Using %r backend as large result store", store_type)
-        self.storage_adapter = build_storage_adapter(large_result_config)
+        log.info("Using %r backend as large run-data store", store_type)
+        self.storage_adapter = build_storage_adapter(self.ctx.config)
 
     @staticmethod
     def _warn_if_cors_regex(origins: str | list[str]) -> None:

--- a/vantage6-server/vantage6/server/controller/cleanup.py
+++ b/vantage6-server/vantage6/server/controller/cleanup.py
@@ -50,9 +50,9 @@ def cleanup_runs_data(config: dict, include_input: bool = False):
                     and run.blob_storage_used == True
                     and storage_adapter
                 ):
-                    log.debug(f"Deleting blob: {run.result}")
+                    log.debug(f"Deleting run data: {run.result}")
                     try:
-                        storage_adapter.delete_blob(run.result)
+                        storage_adapter.delete_run_data(run.result)
                     except Exception as e:
                         log.warning(f"Failed to delete result {run.result}: {e}")
                 run.result = ""
@@ -62,9 +62,9 @@ def cleanup_runs_data(config: dict, include_input: bool = False):
                         and run.blob_storage_used == True
                         and storage_adapter
                     ):
-                        log.debug(f"Deleting blob: {run.input}")
+                        log.debug(f"Deleting run data: {run.input}")
                         try:
-                            storage_adapter.delete_blob(run.input)
+                            storage_adapter.delete_run_data(run.input)
                         except Exception as e:
                             log.warning(f"Failed to delete input {run.input}: {e}")
                     run.input = ""

--- a/vantage6-server/vantage6/server/controller/cleanup.py
+++ b/vantage6-server/vantage6/server/controller/cleanup.py
@@ -22,7 +22,7 @@ def cleanup_runs_data(config: dict, include_input: bool = False):
         The number of days after which results should be cleared.
     """
     days = config.get("runs_data_cleanup_days")
-    storage_adapter = build_storage_adapter(config.get("large_result_store", {}))
+    storage_adapter = build_storage_adapter(config)
     threshold_date = datetime.now(timezone.utc) - timedelta(days=days)
     session = DatabaseSessionManager.get_session()
 

--- a/vantage6-server/vantage6/server/controller/cleanup.py
+++ b/vantage6-server/vantage6/server/controller/cleanup.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from vantage6.common.task_status import TaskStatus
 from vantage6.server.model import Run
 from vantage6.server.model.base import DatabaseSessionManager
-from vantage6.server.service.azure_storage_service import AzureStorageService
+from vantage6.server.service.storage_adapter import build_storage_adapter
 
 module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
@@ -22,9 +22,7 @@ def cleanup_runs_data(config: dict, include_input: bool = False):
         The number of days after which results should be cleared.
     """
     days = config.get("runs_data_cleanup_days")
-    azure_config = config.get("large_result_store", {})
-    if azure_config:
-        storage_adapter = AzureStorageService(azure_config)
+    storage_adapter = build_storage_adapter(config.get("large_result_store", {}))
     threshold_date = datetime.now(timezone.utc) - timedelta(days=days)
     session = DatabaseSessionManager.get_session()
 

--- a/vantage6-server/vantage6/server/resource/__init__.py
+++ b/vantage6-server/vantage6/server/resource/__init__.py
@@ -19,7 +19,7 @@ from vantage6.server.permission import (
     obtain_auth_collaborations,
     obtain_auth_organization,
 )
-from vantage6.server.service.azure_storage_service import AzureStorageService
+from vantage6.server.service.storage_adapter import StorageAdapter
 
 log = logging.getLogger(logger_name(__name__))
 
@@ -35,7 +35,7 @@ class ServicesResources(BaseServicesResources):
     ----------
     socketio : SocketIO
         SocketIO instance
-    storage_adapter : AzureStorageService | None
+    storage_adapter : StorageAdapter | None
         Storage adapter for handling large files
     mail : Mail
         Mail instance
@@ -50,7 +50,7 @@ class ServicesResources(BaseServicesResources):
     def __init__(
         self,
         socketio: SocketIO,
-        storage_adapter: AzureStorageService | None,
+        storage_adapter: StorageAdapter | None,
         mail: Mail,
         api: Api,
         permissions: PermissionManager,

--- a/vantage6-server/vantage6/server/resource/blobstream.py
+++ b/vantage6-server/vantage6/server/resource/blobstream.py
@@ -308,8 +308,7 @@ class UwsgiChunkedStream:
 
     Each call to ``uwsgi.chunked_read(timeout)`` returns the next HTTP
     chunk delivered by the client; the argument is a per-call timeout in
-    seconds (uwsgi defaults to 4). The amount returned is determined by
-    the client's chunk sizing — not by this argument.
+    seconds (uwsgi defaults to 4).
     """
 
     # TODO: Using uwsgi in python in combination with flask is not ideal.

--- a/vantage6-server/vantage6/server/resource/blobstream.py
+++ b/vantage6-server/vantage6/server/resource/blobstream.py
@@ -270,11 +270,14 @@ class BlobStream(BlobStreamBase):
                 data = request.get_data()
                 self.storage_adapter.store_run_data(result_uuid, data)
         except Exception as e:
-            # "unable to receive chunked part" is what uwsgi raises when a
-            # single chunked-input part exceeds ``--chunked-input-limit``.
-            # Storage adapters wrap the underlying IOError into RuntimeError
-            # but preserve the message, so we match on substring rather than
-            # type. Convert to a structured 413 so callers can self-diagnose.
+            # "unable to receive chunked part" is the error uwsgi raises
+            # *most commonly* when a single chunked-input part exceeds
+            # ``--chunked-input-limit``, but the same error string can come
+            # from other transport-level issues (client disconnects mid-part,
+            # malformed chunk framing, …). We surface a 413 because exceeding
+            # the limit is the dominant case and the only one the client can
+            # remediate on its own, but the message is intentionally vague:
+            # check the server logs for the underlying cause.
             if "unable to receive chunked part" in str(e).lower():
                 log.error(
                     "Chunked upload rejected for run data %s: %s (limit=%d bytes)",
@@ -284,9 +287,12 @@ class BlobStream(BlobStreamBase):
                 )
                 return {
                     "msg": (
-                        "Upload rejected: a single chunked-input part "
-                        f"exceeded the server limit of {MAX_CHUNKED_INPUT_PART} "
-                        "bytes. Reduce the per-chunk upload size."
+                        "Upload rejected while receiving a chunked-input "
+                        f"part. The server's per-part limit is "
+                        f"{MAX_CHUNKED_INPUT_PART} bytes — exceeding that "
+                        "is the most likely cause, but the same error can "
+                        "come from other transport-level issues; check the "
+                        "server logs to confirm."
                     ),
                     "max_chunked_input_part": MAX_CHUNKED_INPUT_PART,
                 }, HTTPStatus.REQUEST_ENTITY_TOO_LARGE

--- a/vantage6-server/vantage6/server/resource/blobstream.py
+++ b/vantage6-server/vantage6/server/resource/blobstream.py
@@ -274,10 +274,10 @@ class BlobStream(BlobStreamBase):
             # *most commonly* when a single chunked-input part exceeds
             # ``--chunked-input-limit``, but the same error string can come
             # from other transport-level issues (client disconnects mid-part,
-            # malformed chunk framing, …). We surface a 413 because exceeding
-            # the limit is the dominant case and the only one the client can
-            # remediate on its own, but the message is intentionally vague:
-            # check the server logs for the underlying cause.
+            # malformed chunk framing, …). Because we can't know which one
+            # we hit, the response is a generic 400 — a 413 would assert
+            # too much. The message and ``max_chunked_input_part`` field
+            # let the client try the per-part-limit hypothesis first.
             if "unable to receive chunked part" in str(e).lower():
                 log.error(
                     "Chunked upload rejected for run data %s: %s (limit=%d bytes)",
@@ -295,7 +295,7 @@ class BlobStream(BlobStreamBase):
                         "server logs to confirm."
                     ),
                     "max_chunked_input_part": MAX_CHUNKED_INPUT_PART,
-                }, HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+                }, HTTPStatus.BAD_REQUEST
             log.error(f"Error uploading result: {e}")
             return {"msg": "Error uploading result!"}, HTTPStatus.INTERNAL_SERVER_ERROR
 

--- a/vantage6-server/vantage6/server/resource/blobstream.py
+++ b/vantage6-server/vantage6/server/resource/blobstream.py
@@ -99,7 +99,7 @@ class BlobStreamBase(ServicesResources):
 class BlobStreamStatus(BlobStreamBase):
     """
     Resource for /api/blobstream/status (GET)
-    Returns whether the blob store is enabled.
+    Returns whether the large result store is enabled.
     """
 
     def __init__(self, socketio, storage_adapter, mail, api, permissions, config):
@@ -107,11 +107,11 @@ class BlobStreamStatus(BlobStreamBase):
 
     @only_for(("node", "user", "container"))
     def get(self):
-        """Get the status of the blob store
+        """Get the status of the large result store
         ---
 
         description: >-
-            Returns whether or not blob storage is enabled. \n
+            Returns whether or not the large result store is enabled. \n
 
         responses:
           200:
@@ -122,7 +122,7 @@ class BlobStreamStatus(BlobStreamBase):
         security:
           - bearerAuth: []
         """
-        log.debug("Checking if blob store is enabled")
+        log.debug("Checking if large result store is enabled")
 
         if self.storage_adapter:
             return {"blob_store_enabled": True}, HTTPStatus.OK
@@ -133,7 +133,8 @@ class BlobStreamStatus(BlobStreamBase):
 class BlobStream(BlobStreamBase):
     """
     Resource for /api/blobstream/<id> (GET) and /api/blobstream (POST)
-    This resource allows for streaming large results from blob Storage.
+    This resource allows for streaming large run data (inputs and results)
+    from the configured large result store.
     """
 
     def __init__(self, socketio, storage_adapter, mail, api, permissions, config):
@@ -141,22 +142,23 @@ class BlobStream(BlobStreamBase):
 
     @only_for(("node", "user", "container"))
     def get(self, id):
-        """Stream the result or input with the given id from blob storage.
+        """Stream the result or input with the given id from the large result store.
         ---
 
         description: >-
-            Streams the result or input with the given id from blob storage.
+            Streams the result or input with the given id from the large
+            result store.
 
             ### Permission Table\n
             |Rule name|Scope|Operation|Assigned to node|Assigned to container|
             Description|\n
             |--|--|--|--|--|--|\n
-            |Blobstream|Global|View|❌|❌|View any blob|\n
-            |Blobstream|Collaboration|View|✅|✅|View the blobs of your
+            |Blobstream|Global|View|❌|❌|View any run data|\n
+            |Blobstream|Collaboration|View|✅|✅|View the run data of your
             organization's collaborations|\n
-            |Blobstream|Organization|View|❌|❌|View any blob from a task created by
+            |Blobstream|Organization|View|❌|❌|View any run data from a task created by
             your organization|\n
-            |Blobstream|Own|View|❌|❌|View any blob from a task created by you|\n
+            |Blobstream|Own|View|❌|❌|View any run data from a task created by you|\n
 
             Accessible to users.
 
@@ -188,18 +190,18 @@ class BlobStream(BlobStreamBase):
             }, HTTPStatus.UNAUTHORIZED
 
         if not self.storage_adapter:
-            not_available_msg = "The large result store is not set to blob storage, result streaming is not available."
+            not_available_msg = "The large result store is not configured, result streaming is not available."
             log.warning(not_available_msg)
             return {"msg": not_available_msg}, HTTPStatus.NOT_IMPLEMENTED
         try:
             log.debug(f"Streaming result for run id={id}")
-            blob_stream = self.storage_adapter.stream_blob(id)
+            data_stream = self.storage_adapter.stream_run_data(id)
         except Exception as e:
             log.error(f"Error streaming result: {e}")
             return {"msg": "Error streaming result!"}, HTTPStatus.INTERNAL_SERVER_ERROR
 
         def generate():
-            for chunk in blob_stream.chunks():
+            for chunk in data_stream.chunks():
                 yield chunk
 
         return Response(
@@ -210,12 +212,12 @@ class BlobStream(BlobStreamBase):
 
     @only_for(("node", "user", "container"))
     def post(self):
-        """Post a result to the blob storage.
-        blobs are streamed directly to the blob storage.
+        """Post a result to the large result store.
+        Run data is streamed directly to the large result store.
         This is useful for large results that cannot be loaded into memory at once.
         ---
         description: >-
-          Stream and store blob to blob storage.
+          Stream and store run data to the large result store.
 
         requestBody:
           content:
@@ -233,24 +235,24 @@ class BlobStream(BlobStreamBase):
         tags: ["Algorithm"]
         """
         if not self.storage_adapter:
-            not_available_msg = "The large result store is not set to blob storage, result streaming is not available."
+            not_available_msg = "The large result store is not configured, result streaming is not available."
             log.warning(not_available_msg)
             return {"msg": not_available_msg}, HTTPStatus.NOT_IMPLEMENTED
 
         if g.user and not self.r_task.has_at_least_scope(Scope.COLLABORATION, P.CREATE):
             return {
-                "msg": "You do not have permission to upload blobs. This requires permission to create tasks which you don't have."
+                "msg": "You do not have permission to upload run data. This requires permission to create tasks which you don't have."
             }, HTTPStatus.UNAUTHORIZED
         if g.container:
             container = g.container
             if has_task_finished(db_Task.get(container["task_id"]).status):
                 log.warning(
                     f"Container from node={container['node_id']} "
-                    f"attempts to upload blob for a sub-task of a completed "
+                    f"attempts to upload run data for a sub-task of a completed "
                     f"task={container['task_id']}"
                 )
                 return {
-                    "msg": "Cannot upload blob for a sub-task of a completed task."
+                    "msg": "Cannot upload run data for a sub-task of a completed task."
                 }, HTTPStatus.FORBIDDEN
 
         result_uuid = str(uuid.uuid4())
@@ -263,10 +265,10 @@ class BlobStream(BlobStreamBase):
             # to a different server might solve this issue.
             if is_chunked:
                 stream = UwsgiChunkedStream()
-                self.storage_adapter.store_blob(result_uuid, stream)
+                self.storage_adapter.store_run_data(result_uuid, stream)
             else:
                 data = request.get_data()
-                self.storage_adapter.store_blob(result_uuid, data)
+                self.storage_adapter.store_run_data(result_uuid, data)
         except Exception as e:
             # "unable to receive chunked part" is what uwsgi raises when a
             # single chunked-input part exceeds ``--chunked-input-limit``.
@@ -275,7 +277,7 @@ class BlobStream(BlobStreamBase):
             # type. Convert to a structured 413 so callers can self-diagnose.
             if "unable to receive chunked part" in str(e).lower():
                 log.error(
-                    "Chunked upload rejected for blob %s: %s (limit=%d bytes)",
+                    "Chunked upload rejected for run data %s: %s (limit=%d bytes)",
                     result_uuid,
                     e,
                     MAX_CHUNKED_INPUT_PART,

--- a/vantage6-server/vantage6/server/resource/blobstream.py
+++ b/vantage6-server/vantage6/server/resource/blobstream.py
@@ -15,6 +15,7 @@ from flask_restful import Api
 from http import HTTPStatus
 
 from vantage6.common import logger_name
+from vantage6.common.globals import MAX_CHUNKED_INPUT_PART
 from vantage6.common.task_status import has_task_finished
 from vantage6.server.permission import RuleCollection, Operation as P, Scope
 from vantage6.server.resource import (
@@ -23,6 +24,8 @@ from vantage6.server.resource import (
 )
 from vantage6.server.model import Run as db_Run, Task as db_Task
 
+
+_DEFAULT_CHUNKED_READ_TIMEOUT_S = 30
 
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
@@ -265,6 +268,26 @@ class BlobStream(BlobStreamBase):
                 data = request.get_data()
                 self.storage_adapter.store_blob(result_uuid, data)
         except Exception as e:
+            # "unable to receive chunked part" is what uwsgi raises when a
+            # single chunked-input part exceeds ``--chunked-input-limit``.
+            # Storage adapters wrap the underlying IOError into RuntimeError
+            # but preserve the message, so we match on substring rather than
+            # type. Convert to a structured 413 so callers can self-diagnose.
+            if "unable to receive chunked part" in str(e).lower():
+                log.error(
+                    "Chunked upload rejected for blob %s: %s (limit=%d bytes)",
+                    result_uuid,
+                    e,
+                    MAX_CHUNKED_INPUT_PART,
+                )
+                return {
+                    "msg": (
+                        "Upload rejected: a single chunked-input part "
+                        f"exceeded the server limit of {MAX_CHUNKED_INPUT_PART} "
+                        "bytes. Reduce the per-chunk upload size."
+                    ),
+                    "max_chunked_input_part": MAX_CHUNKED_INPUT_PART,
+                }, HTTPStatus.REQUEST_ENTITY_TOO_LARGE
             log.error(f"Error uploading result: {e}")
             return {"msg": "Error uploading result!"}, HTTPStatus.INTERNAL_SERVER_ERROR
 
@@ -273,17 +296,18 @@ class BlobStream(BlobStreamBase):
 
 class UwsgiChunkedStream:
     """
-    Read data in chunks from uwsgi.
+    File-like reader over a uwsgi chunked HTTP request body.
+
+    Each call to ``uwsgi.chunked_read(timeout)`` returns the next HTTP
+    chunk delivered by the client; the argument is a per-call timeout in
+    seconds (uwsgi defaults to 4). The amount returned is determined by
+    the client's chunk sizing — not by this argument.
     """
 
     # TODO: Using uwsgi in python in combination with flask is not ideal.
     # It would be better to switch to a different server in the long term.
-    #
-    def __init__(self, chunk_size=4096):
-        """
-        Initialize the UwsgiChunkedStream.
-        """
-        self.chunk_size = chunk_size
+    def __init__(self, read_timeout_seconds: int = _DEFAULT_CHUNKED_READ_TIMEOUT_S):
+        self.read_timeout_seconds = read_timeout_seconds
         self._buffer = b""
         self._eof = False
 
@@ -296,7 +320,7 @@ class UwsgiChunkedStream:
             chunks = [self._buffer]
             self._buffer = b""
             while not self._eof:
-                chunk = uwsgi.chunked_read(self.chunk_size)
+                chunk = uwsgi.chunked_read(self.read_timeout_seconds)
                 if not chunk:
                     self._eof = True
                     break
@@ -304,7 +328,7 @@ class UwsgiChunkedStream:
             return b"".join(chunks)
 
         while len(self._buffer) < size and not self._eof:
-            chunk = uwsgi.chunked_read(self.chunk_size)
+            chunk = uwsgi.chunked_read(self.read_timeout_seconds)
             if not chunk:
                 self._eof = True
                 break

--- a/vantage6-server/vantage6/server/resource/task.py
+++ b/vantage6-server/vantage6/server/resource/task.py
@@ -761,7 +761,7 @@ class Tasks(TaskBase):
         # to the database as it may be sensitive information. Vice versa, if
         # the collaboration is not encrypted, we should not allow the user to
         # send encrypted input.
-        blob_storage_used = bool(config.get("large_result_store", {}))
+        blob_storage_used = config.get("large_run_data_store") is not None
 
         is_valid_input, error_msg = Tasks._check_input(
             organizations_json_list, collaboration, blob_storage_used

--- a/vantage6-server/vantage6/server/service/azure_storage_service.py
+++ b/vantage6-server/vantage6/server/service/azure_storage_service.py
@@ -66,81 +66,88 @@ class AzureStorageService(StorageAdapter):
         )
         super().__init__(config)
 
-    def get_blob(self, blob_name: str) -> bytes:
+    def get_run_data(self, name: str) -> bytes:
         """
-        Retrieve a blob from Azure Blob Storage by its name.
+        Retrieve a run-data entry from Azure Blob Storage by its name.
 
         Parameters
         ----------
-        blob_name : str
-            The name of the blob to retrieve.
+        name : str
+            The name of the run-data entry (Azure blob) to retrieve.
 
         Returns
         -------
         bytes
-            The content of the blob.
+            The content of the run-data entry.
         """
-        log.debug(f"Retrieving blob: {blob_name} from container: {self.container_name}")
+        log.debug(
+            f"Retrieving run data: {name} from container: {self.container_name}"
+        )
         blob_client = self.blob_service_client.get_blob_client(
-            container=self.container_name, blob=blob_name
+            container=self.container_name, blob=name
         )
         stream = blob_client.download_blob()
         return stream.readall()
 
-    def store_blob(self, blob_name: str, data: Union[IO, bytes]) -> None:
+    def store_run_data(self, name: str, data: Union[IO, bytes]) -> None:
         """
-        Store data as a blob in Azure Blob Storage.
+        Store data as a run-data entry in Azure Blob Storage.
 
         Parameters
         ----------
-        blob_name : str
-            The name of the blob to create or overwrite.
+        name : str
+            The name of the run-data entry (Azure blob) to create or
+            overwrite.
         data : Union[IO, bytes]
-            The data to store in the blob. Can be a bytes object or a file-like
+            The data to store. Can be a bytes object or a file-like
             object.
         """
-        log.debug(f"Storing blob: {blob_name} in container: {self.container_name}")
+        log.debug(f"Storing run data: {name} in container: {self.container_name}")
         blob_client = self.blob_service_client.get_blob_client(
-            container=self.container_name, blob=blob_name
+            container=self.container_name, blob=name
         )
         try:
             blob_client.upload_blob(data, overwrite=True)
         except Exception as e:
-            log.error(f"Failed to upload blob '{blob_name}': {e}")
-            raise RuntimeError(f"Failed to upload blob '{blob_name}': {e}")
+            log.error(f"Failed to upload run data '{name}': {e}")
+            raise RuntimeError(f"Failed to upload run data '{name}': {e}")
 
-    def delete_blob(self, blob_name: str) -> None:
+    def delete_run_data(self, name: str) -> None:
         """
-        Delete a blob from Azure Blob Storage by its name.
+        Delete a run-data entry from Azure Blob Storage by its name.
 
         Parameters
         ----------
-        blob_name : str
-            The name of the blob to delete.
+        name : str
+            The name of the run-data entry (Azure blob) to delete.
         """
-        log.debug(f"Deleting blob: {blob_name} from container: {self.container_name}")
+        log.debug(
+            f"Deleting run data: {name} from container: {self.container_name}"
+        )
         blob_client = self.blob_service_client.get_blob_client(
-            container=self.container_name, blob=blob_name
+            container=self.container_name, blob=name
         )
         blob_client.delete_blob()
 
-    def stream_blob(self, blob_name: str):
+    def stream_run_data(self, name: str):
         """
-        Stream a blob from Azure Blob Storage.
+        Stream a run-data entry from Azure Blob Storage.
         Returns a StorageStreamDownloader object.
 
         Parameters
         ----------
-        blob_name : str
-            The name of the blob to stream.
+        name : str
+            The name of the run-data entry (Azure blob) to stream.
 
         Returns
         -------
         StorageStreamDownloader
-            A stream object to read the blob's content in chunks.
+            A stream object to read the run-data entry's content in chunks.
         """
-        log.debug(f"Streaming blob: {blob_name} from container: {self.container_name}")
+        log.debug(
+            f"Streaming run data: {name} from container: {self.container_name}"
+        )
         blob_client = self.blob_service_client.get_blob_client(
-            container=self.container_name, blob=blob_name
+            container=self.container_name, blob=name
         )
         return blob_client.download_blob()

--- a/vantage6-server/vantage6/server/service/azure_storage_service.py
+++ b/vantage6-server/vantage6/server/service/azure_storage_service.py
@@ -1,18 +1,19 @@
+"""Azure Blob Storage backend for the large result store."""
+
 import logging
 from typing import IO, Union
 
 from azure.identity import ClientSecretCredential
 from azure.storage.blob import BlobServiceClient
-from sqlalchemy import event
 
 from vantage6.common import logger_name
-from vantage6.server.model.run import Run
+from vantage6.server.service.storage_adapter import StorageAdapter
 
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 
 
-class AzureStorageService:
+class AzureStorageService(StorageAdapter):
     """
     A service for managing Azure Blob Storage.
     """
@@ -63,7 +64,7 @@ class AzureStorageService:
         self.container_client = self.blob_service_client.get_container_client(
             container_name
         )
-        event.listen(Run, "after_delete", self.delete_blob_after_run_delete)
+        super().__init__(config)
 
     def get_blob(self, blob_name: str) -> bytes:
         """
@@ -143,19 +144,3 @@ class AzureStorageService:
             container=self.container_name, blob=blob_name
         )
         return blob_client.download_blob()
-
-    def delete_blob_after_run_delete(self, mapper, connection, target):
-        """
-        SQLAlchemy event listener to delete the associated blob when a Run
-        instance is deleted.
-        """
-        if target.blob_storage_used:
-            try:
-                if target.result:
-                    self.delete_blob(target.result)
-                if target.input:
-                    self.delete_blob(target.input)
-            except Exception as e:
-                error_msg = f"Failed to delete blob for run {target.id}: {e}"
-                log.error(error_msg)
-                raise RuntimeError(error_msg)

--- a/vantage6-server/vantage6/server/service/azure_storage_service.py
+++ b/vantage6-server/vantage6/server/service/azure_storage_service.py
@@ -8,7 +8,10 @@ from azure.identity import ClientSecretCredential
 from azure.storage.blob import BlobServiceClient
 
 from vantage6.common import logger_name
-from vantage6.server.service.storage_adapter import StorageAdapter
+from vantage6.server.service.storage_adapter import (
+    RunDataNotFoundError,
+    StorageAdapter,
+)
 
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
@@ -91,7 +94,7 @@ class AzureStorageService(StorageAdapter):
             stream = blob_client.download_blob()
             return stream.readall()
         except ResourceNotFoundError as e:
-            raise FileNotFoundError(f"Run data {name!r} not found") from e
+            raise RunDataNotFoundError(f"Run data {name!r} not found") from e
 
     def store_run_data(self, name: str, data: Union[IO, bytes]) -> None:
         """
@@ -163,4 +166,4 @@ class AzureStorageService(StorageAdapter):
         try:
             return blob_client.download_blob()
         except ResourceNotFoundError as e:
-            raise FileNotFoundError(f"Run data {name!r} not found") from e
+            raise RunDataNotFoundError(f"Run data {name!r} not found") from e

--- a/vantage6-server/vantage6/server/service/azure_storage_service.py
+++ b/vantage6-server/vantage6/server/service/azure_storage_service.py
@@ -3,6 +3,7 @@
 import logging
 from typing import IO, Union
 
+from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import ClientSecretCredential
 from azure.storage.blob import BlobServiceClient
 
@@ -86,8 +87,11 @@ class AzureStorageService(StorageAdapter):
         blob_client = self.blob_service_client.get_blob_client(
             container=self.container_name, blob=name
         )
-        stream = blob_client.download_blob()
-        return stream.readall()
+        try:
+            stream = blob_client.download_blob()
+            return stream.readall()
+        except ResourceNotFoundError as e:
+            raise FileNotFoundError(f"Run data {name!r} not found") from e
 
     def store_run_data(self, name: str, data: Union[IO, bytes]) -> None:
         """
@@ -127,7 +131,13 @@ class AzureStorageService(StorageAdapter):
         blob_client = self.blob_service_client.get_blob_client(
             container=self.container_name, blob=name
         )
-        blob_client.delete_blob()
+        try:
+            blob_client.delete_blob()
+        except ResourceNotFoundError:
+            # StorageAdapter.delete_run_data is contractually idempotent;
+            # the after_delete listener relies on this when a Run row whose
+            # blob has already been deleted is removed from the DB.
+            pass
 
     def stream_run_data(self, name: str):
         """
@@ -150,4 +160,7 @@ class AzureStorageService(StorageAdapter):
         blob_client = self.blob_service_client.get_blob_client(
             container=self.container_name, blob=name
         )
-        return blob_client.download_blob()
+        try:
+            return blob_client.download_blob()
+        except ResourceNotFoundError as e:
+            raise FileNotFoundError(f"Run data {name!r} not found") from e

--- a/vantage6-server/vantage6/server/service/file_storage_service.py
+++ b/vantage6-server/vantage6/server/service/file_storage_service.py
@@ -1,15 +1,15 @@
 """Local-filesystem backend for the large result store.
 
-Blobs are written under a configurable ``base_path`` using a two-character
-shard derived from the blob name: ``{base_path}/{name[:2]}/{name}``. This
-keeps any single directory's fan-out bounded while still being trivial
-to reason about.
+Run-data entries are written under a configurable ``base_path`` using a
+two-character shard derived from the name: ``{base_path}/{name[:2]}/{name}``.
+This keeps any single directory's fan-out bounded while still being
+trivial to reason about.
 
 Writes are atomic: a tempfile is written in the same shard directory,
 ``fsync``-ed, and then ``os.replace``-d into place, so readers never
-observe a half-written blob. For multi-replica deployments ``base_path``
+observe a half-written entry. For multi-replica deployments ``base_path``
 must point at a shared filesystem (NFS, Azure Files, …) — otherwise
-replicas will not see each other's blobs.
+replicas will not see each other's run data.
 """
 
 import logging
@@ -21,17 +21,17 @@ from typing import IO, Iterator, Union
 
 from vantage6.common import logger_name
 from vantage6.common.globals import DEFAULT_CHUNK_SIZE
-from vantage6.server.service.storage_adapter import BlobStream, StorageAdapter
+from vantage6.server.service.storage_adapter import RunDataStream, StorageAdapter
 
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 
-_BLOB_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
-BLOB_BASE_PATH_ENV_VAR = "VANTAGE6_BLOB_BASE_PATH"
+_RUN_DATA_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+RUN_DATA_BASE_PATH_ENV_VAR = "VANTAGE6_RUN_DATA_BASE_PATH"
 
 
-class FileBlobStream(BlobStream):
-    """Streaming reader for a blob stored on the local filesystem."""
+class FileRunDataStream(RunDataStream):
+    """Streaming reader for run data stored on the local filesystem."""
 
     def __init__(self, path: Path) -> None:
         self._path = path
@@ -49,20 +49,22 @@ class FileStorageService(StorageAdapter):
     """Filesystem-backed implementation of :class:`StorageAdapter`."""
 
     def __init__(self, config: dict) -> None:
-        base_path = os.environ.get(BLOB_BASE_PATH_ENV_VAR) or config.get("base_path")
+        base_path = os.environ.get(RUN_DATA_BASE_PATH_ENV_VAR) or config.get(
+            "base_path"
+        )
         if not base_path:
             raise ValueError(
                 "File storage base path must be provided via the "
-                f"{BLOB_BASE_PATH_ENV_VAR} environment variable or the "
+                f"{RUN_DATA_BASE_PATH_ENV_VAR} environment variable or the "
                 "'base_path' key of the large_result_store config."
             )
 
         root = Path(base_path).expanduser().resolve()
         container_name = config.get("container_name")
         if container_name:
-            if not _BLOB_NAME_RE.match(container_name):
+            if not _RUN_DATA_NAME_RE.match(container_name):
                 raise ValueError(
-                    f"Invalid container_name {container_name!r}: must match {_BLOB_NAME_RE.pattern}"
+                    f"Invalid container_name {container_name!r}: must match {_RUN_DATA_NAME_RE.pattern}"
                 )
             root = root / container_name
 
@@ -74,23 +76,23 @@ class FileStorageService(StorageAdapter):
         log.info("File storage adapter initialised at %s", self.base_path)
         super().__init__(config)
 
-    def _path_for(self, blob_name: str) -> Path:
-        if not isinstance(blob_name, str) or not _BLOB_NAME_RE.match(blob_name):
-            raise ValueError(f"Invalid blob name: {blob_name!r}")
-        return self.base_path / blob_name[:2] / blob_name
+    def _path_for(self, name: str) -> Path:
+        if not isinstance(name, str) or not _RUN_DATA_NAME_RE.match(name):
+            raise ValueError(f"Invalid run-data name: {name!r}")
+        return self.base_path / name[:2] / name
 
-    def get_blob(self, blob_name: str) -> bytes:
-        path = self._path_for(blob_name)
-        log.debug("Retrieving blob: %s", path)
+    def get_run_data(self, name: str) -> bytes:
+        path = self._path_for(name)
+        log.debug("Retrieving run data: %s", path)
         return path.read_bytes()
 
-    def store_blob(self, blob_name: str, data: Union[IO, bytes]) -> None:
-        target = self._path_for(blob_name)
-        log.debug("Storing blob: %s", target)
+    def store_run_data(self, name: str, data: Union[IO, bytes]) -> None:
+        target = self._path_for(name)
+        log.debug("Storing run data: %s", target)
         target.parent.mkdir(parents=True, exist_ok=True)
 
         tmp = tempfile.NamedTemporaryFile(
-            dir=target.parent, prefix=".tmp-", suffix=f"-{blob_name}", delete=False
+            dir=target.parent, prefix=".tmp-", suffix=f"-{name}", delete=False
         )
         tmp_path = Path(tmp.name)
         try:
@@ -116,24 +118,24 @@ class FileStorageService(StorageAdapter):
                 tmp_path.unlink(missing_ok=True)
             except Exception:
                 pass
-            log.error("Failed to store blob %r: %s", blob_name, e)
-            raise RuntimeError(f"Failed to store blob {blob_name!r}: {e}") from e
+            log.error("Failed to store run data %r: %s", name, e)
+            raise RuntimeError(f"Failed to store run data {name!r}: {e}") from e
 
-    def delete_blob(self, blob_name: str) -> None:
-        path = self._path_for(blob_name)
-        log.debug("Deleting blob: %s", path)
+    def delete_run_data(self, name: str) -> None:
+        path = self._path_for(name)
+        log.debug("Deleting run data: %s", path)
         path.unlink(missing_ok=True)
         try:
             path.parent.rmdir()
         except OSError:
             pass
 
-    def stream_blob(self, blob_name: str) -> FileBlobStream:
-        path = self._path_for(blob_name)
-        log.debug("Streaming blob: %s", path)
+    def stream_run_data(self, name: str) -> FileRunDataStream:
+        path = self._path_for(name)
+        log.debug("Streaming run data: %s", path)
         if not path.exists():
-            raise FileNotFoundError(f"Blob {blob_name!r} not found at {path}")
-        return FileBlobStream(path)
+            raise FileNotFoundError(f"Run data {name!r} not found at {path}")
+        return FileRunDataStream(path)
 
     @staticmethod
     def _fsync_dir(directory: Path) -> None:

--- a/vantage6-server/vantage6/server/service/file_storage_service.py
+++ b/vantage6-server/vantage6/server/service/file_storage_service.py
@@ -1,0 +1,149 @@
+"""Local-filesystem backend for the large result store.
+
+Blobs are written under a configurable ``base_path`` using a two-character
+shard derived from the blob name: ``{base_path}/{name[:2]}/{name}``. This
+keeps any single directory's fan-out bounded while still being trivial
+to reason about.
+
+Writes are atomic: a tempfile is written in the same shard directory,
+``fsync``-ed, and then ``os.replace``-d into place, so readers never
+observe a half-written blob. For multi-replica deployments ``base_path``
+must point at a shared filesystem (NFS, Azure Files, …) — otherwise
+replicas will not see each other's blobs.
+"""
+
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import IO, Iterator, Union
+
+from vantage6.common import logger_name
+from vantage6.common.globals import DEFAULT_CHUNK_SIZE
+from vantage6.server.service.storage_adapter import BlobStream, StorageAdapter
+
+module_name = logger_name(__name__)
+log = logging.getLogger(module_name)
+
+_BLOB_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+BLOB_BASE_PATH_ENV_VAR = "VANTAGE6_BLOB_BASE_PATH"
+
+
+class FileBlobStream(BlobStream):
+    """Streaming reader for a blob stored on the local filesystem."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def chunks(self) -> Iterator[bytes]:
+        with self._path.open("rb") as f:
+            while True:
+                chunk = f.read(DEFAULT_CHUNK_SIZE)
+                if not chunk:
+                    return
+                yield chunk
+
+
+class FileStorageService(StorageAdapter):
+    """Filesystem-backed implementation of :class:`StorageAdapter`."""
+
+    def __init__(self, config: dict) -> None:
+        base_path = os.environ.get(BLOB_BASE_PATH_ENV_VAR) or config.get("base_path")
+        if not base_path:
+            raise ValueError(
+                "File storage base path must be provided via the "
+                f"{BLOB_BASE_PATH_ENV_VAR} environment variable or the "
+                "'base_path' key of the large_result_store config."
+            )
+
+        root = Path(base_path).expanduser().resolve()
+        container_name = config.get("container_name")
+        if container_name:
+            if not _BLOB_NAME_RE.match(container_name):
+                raise ValueError(
+                    f"Invalid container_name {container_name!r}: must match {_BLOB_NAME_RE.pattern}"
+                )
+            root = root / container_name
+
+        root.mkdir(parents=True, exist_ok=True)
+        if not os.access(root, os.W_OK):
+            log.warning("File storage base path %s is not writable.", root)
+
+        self.base_path = root
+        log.info("File storage adapter initialised at %s", self.base_path)
+        super().__init__(config)
+
+    def _path_for(self, blob_name: str) -> Path:
+        if not isinstance(blob_name, str) or not _BLOB_NAME_RE.match(blob_name):
+            raise ValueError(f"Invalid blob name: {blob_name!r}")
+        return self.base_path / blob_name[:2] / blob_name
+
+    def get_blob(self, blob_name: str) -> bytes:
+        path = self._path_for(blob_name)
+        log.debug("Retrieving blob: %s", path)
+        return path.read_bytes()
+
+    def store_blob(self, blob_name: str, data: Union[IO, bytes]) -> None:
+        target = self._path_for(blob_name)
+        log.debug("Storing blob: %s", target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        tmp = tempfile.NamedTemporaryFile(
+            dir=target.parent, prefix=".tmp-", suffix=f"-{blob_name}", delete=False
+        )
+        tmp_path = Path(tmp.name)
+        try:
+            if isinstance(data, (bytes, bytearray, memoryview)):
+                tmp.write(bytes(data))
+            else:
+                while True:
+                    chunk = data.read(DEFAULT_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    tmp.write(chunk)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.replace(tmp_path, target)
+            self._fsync_dir(target.parent)
+        except Exception as e:
+            try:
+                tmp.close()
+            except Exception:
+                pass
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+            log.error("Failed to store blob %r: %s", blob_name, e)
+            raise RuntimeError(f"Failed to store blob {blob_name!r}: {e}") from e
+
+    def delete_blob(self, blob_name: str) -> None:
+        path = self._path_for(blob_name)
+        log.debug("Deleting blob: %s", path)
+        path.unlink(missing_ok=True)
+        try:
+            path.parent.rmdir()
+        except OSError:
+            pass
+
+    def stream_blob(self, blob_name: str) -> FileBlobStream:
+        path = self._path_for(blob_name)
+        log.debug("Streaming blob: %s", path)
+        if not path.exists():
+            raise FileNotFoundError(f"Blob {blob_name!r} not found at {path}")
+        return FileBlobStream(path)
+
+    @staticmethod
+    def _fsync_dir(directory: Path) -> None:
+        try:
+            fd = os.open(directory, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(fd)
+        except OSError:
+            pass
+        finally:
+            os.close(fd)

--- a/vantage6-server/vantage6/server/service/file_storage_service.py
+++ b/vantage6-server/vantage6/server/service/file_storage_service.py
@@ -1,15 +1,23 @@
 """Local-filesystem backend for the large result store.
 
-Run-data entries are written under a configurable ``base_path`` using a
-two-character shard derived from the name: ``{base_path}/{name[:2]}/{name}``.
-This keeps any single directory's fan-out bounded while still being
-trivial to reason about.
+Run-data entries are written under ``base_path`` using a two-character
+shard derived from the name: ``{base_path}/{name[:2]}/{name}``. This
+keeps any single directory's fan-out bounded while still being trivial
+to reason about.
+
+``base_path`` is supplied by the caller. The factory in
+:mod:`vantage6.server.service.storage_adapter` resolves it from the
+``VANTAGE6_RUN_DATA_BASE_PATH`` environment variable, defaulting to
+``/mnt/run_data``. Operators control where run data lives by mounting
+that path into the server container (the ``v6 server start`` CLI does
+this automatically; under docker-compose the user adds a volume mount
+themselves).
 
 Writes are atomic: a tempfile is written in the same shard directory,
 ``fsync``-ed, and then ``os.replace``-d into place, so readers never
-observe a half-written entry. For multi-replica deployments ``base_path``
-must point at a shared filesystem (NFS, Azure Files, …) — otherwise
-replicas will not see each other's run data.
+observe a half-written entry. For multi-replica deployments the mount
+target must point at a shared filesystem (NFS, Azure Files, …) —
+otherwise replicas will not see each other's run data.
 """
 
 import logging
@@ -28,6 +36,7 @@ log = logging.getLogger(module_name)
 
 _RUN_DATA_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
 RUN_DATA_BASE_PATH_ENV_VAR = "VANTAGE6_RUN_DATA_BASE_PATH"
+DEFAULT_RUN_DATA_BASE_PATH = "/mnt/run_data"
 
 
 class FileRunDataStream(RunDataStream):
@@ -48,26 +57,8 @@ class FileRunDataStream(RunDataStream):
 class FileStorageService(StorageAdapter):
     """Filesystem-backed implementation of :class:`StorageAdapter`."""
 
-    def __init__(self, config: dict) -> None:
-        base_path = os.environ.get(RUN_DATA_BASE_PATH_ENV_VAR) or config.get(
-            "base_path"
-        )
-        if not base_path:
-            raise ValueError(
-                "File storage base path must be provided via the "
-                f"{RUN_DATA_BASE_PATH_ENV_VAR} environment variable or the "
-                "'base_path' key of the large_result_store config."
-            )
-
+    def __init__(self, config: dict, base_path: str | Path) -> None:
         root = Path(base_path).expanduser().resolve()
-        container_name = config.get("container_name")
-        if container_name:
-            if not _RUN_DATA_NAME_RE.match(container_name):
-                raise ValueError(
-                    f"Invalid container_name {container_name!r}: must match {_RUN_DATA_NAME_RE.pattern}"
-                )
-            root = root / container_name
-
         root.mkdir(parents=True, exist_ok=True)
         if not os.access(root, os.W_OK):
             log.warning("File storage base path %s is not writable.", root)

--- a/vantage6-server/vantage6/server/service/file_storage_service.py
+++ b/vantage6-server/vantage6/server/service/file_storage_service.py
@@ -29,7 +29,11 @@ from typing import IO, Iterator, Union
 
 from vantage6.common import logger_name
 from vantage6.common.globals import DEFAULT_CHUNK_SIZE
-from vantage6.server.service.storage_adapter import RunDataStream, StorageAdapter
+from vantage6.server.service.storage_adapter import (
+    RunDataNotFoundError,
+    RunDataStream,
+    StorageAdapter,
+)
 
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
@@ -75,9 +79,43 @@ class FileStorageService(StorageAdapter):
     def get_run_data(self, name: str) -> bytes:
         path = self._path_for(name)
         log.debug("Retrieving run data: %s", path)
-        return path.read_bytes()
+        try:
+            return path.read_bytes()
+        except FileNotFoundError as e:
+            raise RunDataNotFoundError(
+                f"Run data {name!r} not found at {path}"
+            ) from e
 
     def store_run_data(self, name: str, data: Union[IO, bytes]) -> None:
+        """Atomically write ``data`` under ``name``.
+
+        The recipe below ("write tempfile in the same dir, fsync, rename,
+        fsync the dir") is the standard POSIX atomic-write pattern. Each
+        step is load-bearing:
+
+        - **Tempfile in the same shard directory.** ``os.replace`` only
+          guarantees atomicity within a single filesystem; writing to
+          ``/tmp`` first and then renaming risks an ``EXDEV`` cross-device
+          error. ``prefix=".tmp-"`` makes incomplete uploads recognisable
+          to cleanup tooling (and to the test that scans for leftovers).
+        - **``flush + fsync`` before the rename.** Without ``fsync``, the
+          file's data may still live in the kernel page cache when
+          ``os.replace`` swings the directory entry. A power-loss between
+          the rename and the eventual writeback would leave a zero-byte
+          or truncated file under ``target``.
+        - **``os.replace`` (not ``Path.rename``).** ``os.replace`` is
+          atomic and overwrites the destination if it already exists,
+          which matters because callers occasionally re-upload the same
+          UUID. ``Path.rename`` raises on POSIX if the target exists.
+        - **``_fsync_dir`` after the rename.** The rename itself is a
+          directory-entry change, and on most filesystems that change is
+          also buffered. Fsyncing the parent directory makes the new
+          name durable across a crash.
+        - **Cleanup in ``except``.** Any failure (write error, OOM, the
+          ``os.replace`` mock in the crash-safety test) must remove the
+          tempfile so we don't leak ``.tmp-*`` files that confuse
+          operators and the leftover-tempfile test.
+        """
         target = self._path_for(name)
         log.debug("Storing run data: %s", target)
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -101,6 +139,9 @@ class FileStorageService(StorageAdapter):
             os.replace(tmp_path, target)
             self._fsync_dir(target.parent)
         except Exception as e:
+            # Tempfile cleanup must be best-effort: the original failure
+            # is what we want to surface, not a secondary close/unlink
+            # error masking it.
             try:
                 tmp.close()
             except Exception:
@@ -125,7 +166,7 @@ class FileStorageService(StorageAdapter):
         path = self._path_for(name)
         log.debug("Streaming run data: %s", path)
         if not path.exists():
-            raise FileNotFoundError(f"Run data {name!r} not found at {path}")
+            raise RunDataNotFoundError(f"Run data {name!r} not found at {path}")
         return FileRunDataStream(path)
 
     @staticmethod

--- a/vantage6-server/vantage6/server/service/storage_adapter.py
+++ b/vantage6-server/vantage6/server/service/storage_adapter.py
@@ -12,8 +12,9 @@ they are fully usable, so the listener is never registered against a
 half-initialised adapter.
 
 The module also exposes :func:`build_storage_adapter`, a small factory
-that dispatches on the ``type`` field of the ``large_result_store``
-configuration block.
+that dispatches on the top-level ``large_run_data_store`` setting (a
+string: ``"filesystem"`` or ``"azure"``). When ``"azure"`` is selected,
+the Azure-specific block lives under ``azure_run_data_store``.
 """
 
 import logging
@@ -94,29 +95,40 @@ class StorageAdapter(ABC):
             raise RuntimeError(error_msg)
 
 
-def build_storage_adapter(config: dict) -> StorageAdapter | None:
+def build_storage_adapter(server_config: dict) -> StorageAdapter | None:
     """Build the configured storage adapter, or return ``None`` if disabled.
 
-    Parameters
-    ----------
-    config : dict
-        The ``large_result_store`` configuration block.
+    Reads two top-level keys from the server config:
 
-    Returns
-    -------
-    StorageAdapter | None
-        Configured adapter, or ``None`` if the block is empty or the
-        ``type`` is unknown.
+    - ``large_run_data_store`` — required string, either ``"filesystem"``
+      or ``"azure"``. Absent means "disabled — use the relational DB
+      for inputs and results".
+    - ``azure_run_data_store`` — required when ``large_run_data_store``
+      is ``"azure"``; ignored otherwise.
+
+    Raises
+    ------
+    ValueError
+        If the deprecated ``large_result_store`` key is present (the
+        config shape changed in this release), if
+        ``large_run_data_store`` is not one of the supported values,
+        or if ``"azure"`` is selected without an
+        ``azure_run_data_store`` block.
     """
-    if not config:
+    if "large_result_store" in server_config:
+        raise ValueError(
+            "Configuration key 'large_result_store' is no longer supported. "
+            "Use top-level 'large_run_data_store: \"filesystem\"' or "
+            "'large_run_data_store: \"azure\"' (with an 'azure_run_data_store' "
+            "block for the Azure credentials). See the docs at "
+            "docs/features/inter-component/blob_storage.rst."
+        )
+
+    store_type = server_config.get("large_run_data_store")
+    if store_type is None:
         return None
 
-    store_type = config.get("type", "file")
-    if store_type == "azure":
-        from vantage6.server.service.azure_storage_service import AzureStorageService
-
-        return AzureStorageService(config=config)
-    if store_type == "file":
+    if store_type == "filesystem":
         from vantage6.server.service.file_storage_service import (
             DEFAULT_RUN_DATA_BASE_PATH,
             RUN_DATA_BASE_PATH_ENV_VAR,
@@ -126,10 +138,20 @@ def build_storage_adapter(config: dict) -> StorageAdapter | None:
         base_path = os.environ.get(
             RUN_DATA_BASE_PATH_ENV_VAR, DEFAULT_RUN_DATA_BASE_PATH
         )
-        return FileStorageService(config=config, base_path=base_path)
+        return FileStorageService(config={}, base_path=base_path)
 
-    log.error(
-        "Unknown large_result_store.type=%r; large result store disabled.",
-        store_type,
+    if store_type == "azure":
+        azure_config = server_config.get("azure_run_data_store")
+        if not azure_config:
+            raise ValueError(
+                "large_run_data_store is 'azure' but no 'azure_run_data_store' "
+                "block was provided in the server config."
+            )
+        from vantage6.server.service.azure_storage_service import AzureStorageService
+
+        return AzureStorageService(config=azure_config)
+
+    raise ValueError(
+        f"Unknown large_run_data_store={store_type!r}; expected "
+        f"'filesystem' or 'azure'."
     )
-    return None

--- a/vantage6-server/vantage6/server/service/storage_adapter.py
+++ b/vantage6-server/vantage6/server/service/storage_adapter.py
@@ -31,6 +31,15 @@ module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 
 
+class RunDataNotFoundError(Exception):
+    """Raised by storage adapters when no entry exists for the given name.
+
+    Backend-neutral: file backend raises this in place of the bare
+    ``FileNotFoundError`` from ``Path.read_bytes()``; Azure backend
+    raises it in place of ``azure.core.exceptions.ResourceNotFoundError``.
+    """
+
+
 class RunDataStream(ABC):
     """Streaming reader for stored run data.
 
@@ -56,7 +65,7 @@ class StorageAdapter(ABC):
 
         Raises
         ------
-        FileNotFoundError
+        RunDataNotFoundError
             If no entry exists for ``name``.
         """
 
@@ -74,7 +83,7 @@ class StorageAdapter(ABC):
 
         Raises
         ------
-        FileNotFoundError
+        RunDataNotFoundError
             If no entry exists for ``name``.
         """
 

--- a/vantage6-server/vantage6/server/service/storage_adapter.py
+++ b/vantage6-server/vantage6/server/service/storage_adapter.py
@@ -1,0 +1,112 @@
+"""Abstract storage adapter for the large result store.
+
+Provides a backend-agnostic interface for storing run inputs and results
+(``store_blob`` / ``get_blob`` / ``stream_blob`` / ``delete_blob``) along
+with a shared SQLAlchemy ``after_delete`` listener on :class:`Run` that
+removes the associated blobs whenever a Run row is deleted.
+
+Concrete backends (Azure Blob Storage, local filesystem) subclass
+:class:`StorageAdapter` and call ``super().__init__(config)`` only after
+they are fully usable, so the listener is never registered against a
+half-initialised adapter.
+
+The module also exposes :func:`build_storage_adapter`, a small factory
+that dispatches on the ``type`` field of the ``large_result_store``
+configuration block.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import IO, Iterator, Union
+
+from sqlalchemy import event
+
+from vantage6.common import logger_name
+from vantage6.server.model.run import Run
+
+module_name = logger_name(__name__)
+log = logging.getLogger(module_name)
+
+
+class BlobStream(ABC):
+    """Streaming reader for a stored blob.
+
+    The shape mirrors Azure SDK's ``StorageStreamDownloader.chunks()`` so
+    the existing call site in ``blobstream.py`` works unchanged for both
+    backends.
+    """
+
+    @abstractmethod
+    def chunks(self) -> Iterator[bytes]:
+        """Yield successive chunks of the blob's content."""
+
+
+class StorageAdapter(ABC):
+    """Abstract base class for large-result storage backends."""
+
+    def __init__(self, config: dict) -> None:
+        event.listen(Run, "after_delete", self._delete_blob_after_run_delete)
+
+    @abstractmethod
+    def get_blob(self, blob_name: str) -> bytes:
+        """Return the full content of a blob as bytes."""
+
+    @abstractmethod
+    def store_blob(self, blob_name: str, data: Union[IO, bytes]) -> None:
+        """Store data under the given blob name."""
+
+    @abstractmethod
+    def delete_blob(self, blob_name: str) -> None:
+        """Delete a blob. Must be idempotent (no error if missing)."""
+
+    @abstractmethod
+    def stream_blob(self, blob_name: str):
+        """Return a streaming reader exposing a ``chunks()`` iterator."""
+
+    def _delete_blob_after_run_delete(self, mapper, connection, target) -> None:
+        """Remove the associated blobs when a Run row is deleted."""
+        if not getattr(target, "blob_storage_used", False):
+            return
+        try:
+            if target.result:
+                self.delete_blob(target.result)
+            if target.input:
+                self.delete_blob(target.input)
+        except Exception as e:
+            error_msg = f"Failed to delete blob for run {target.id}: {e}"
+            log.error(error_msg)
+            raise RuntimeError(error_msg)
+
+
+def build_storage_adapter(config: dict) -> StorageAdapter | None:
+    """Build the configured storage adapter, or return ``None`` if disabled.
+
+    Parameters
+    ----------
+    config : dict
+        The ``large_result_store`` configuration block.
+
+    Returns
+    -------
+    StorageAdapter | None
+        Configured adapter, or ``None`` if the block is empty or the
+        ``type`` is unknown.
+    """
+    if not config:
+        return None
+
+    store_type = config.get("type", "file")
+    if store_type == "azure":
+        from vantage6.server.service.azure_storage_service import AzureStorageService
+
+        return AzureStorageService(config=config)
+    if store_type == "file":
+        from vantage6.server.service.file_storage_service import FileStorageService
+
+        return FileStorageService(config=config)
+
+    log.error(
+        "Unknown large_result_store.type=%r; large result store disabled.",
+        store_type,
+    )
+    return None

--- a/vantage6-server/vantage6/server/service/storage_adapter.py
+++ b/vantage6-server/vantage6/server/service/storage_adapter.py
@@ -17,6 +17,7 @@ configuration block.
 """
 
 import logging
+import os
 from abc import ABC, abstractmethod
 from typing import IO, Iterator, Union
 
@@ -50,7 +51,13 @@ class StorageAdapter(ABC):
 
     @abstractmethod
     def get_run_data(self, name: str) -> bytes:
-        """Return the full content of a run-data entry as bytes."""
+        """Return the full content of a run-data entry as bytes.
+
+        Raises
+        ------
+        FileNotFoundError
+            If no entry exists for ``name``.
+        """
 
     @abstractmethod
     def store_run_data(self, name: str, data: Union[IO, bytes]) -> None:
@@ -62,7 +69,13 @@ class StorageAdapter(ABC):
 
     @abstractmethod
     def stream_run_data(self, name: str):
-        """Return a streaming reader exposing a ``chunks()`` iterator."""
+        """Return a streaming reader exposing a ``chunks()`` iterator.
+
+        Raises
+        ------
+        FileNotFoundError
+            If no entry exists for ``name``.
+        """
 
     def _delete_run_data_after_run_delete(
         self, mapper, connection, target
@@ -104,9 +117,16 @@ def build_storage_adapter(config: dict) -> StorageAdapter | None:
 
         return AzureStorageService(config=config)
     if store_type == "file":
-        from vantage6.server.service.file_storage_service import FileStorageService
+        from vantage6.server.service.file_storage_service import (
+            DEFAULT_RUN_DATA_BASE_PATH,
+            RUN_DATA_BASE_PATH_ENV_VAR,
+            FileStorageService,
+        )
 
-        return FileStorageService(config=config)
+        base_path = os.environ.get(
+            RUN_DATA_BASE_PATH_ENV_VAR, DEFAULT_RUN_DATA_BASE_PATH
+        )
+        return FileStorageService(config=config, base_path=base_path)
 
     log.error(
         "Unknown large_result_store.type=%r; large result store disabled.",

--- a/vantage6-server/vantage6/server/service/storage_adapter.py
+++ b/vantage6-server/vantage6/server/service/storage_adapter.py
@@ -1,9 +1,10 @@
 """Abstract storage adapter for the large result store.
 
 Provides a backend-agnostic interface for storing run inputs and results
-(``store_blob`` / ``get_blob`` / ``stream_blob`` / ``delete_blob``) along
-with a shared SQLAlchemy ``after_delete`` listener on :class:`Run` that
-removes the associated blobs whenever a Run row is deleted.
+(``store_run_data`` / ``get_run_data`` / ``stream_run_data`` /
+``delete_run_data``) along with a shared SQLAlchemy ``after_delete``
+listener on :class:`Run` that removes the associated run data whenever
+a Run row is deleted.
 
 Concrete backends (Azure Blob Storage, local filesystem) subclass
 :class:`StorageAdapter` and call ``super().__init__(config)`` only after
@@ -28,8 +29,8 @@ module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 
 
-class BlobStream(ABC):
-    """Streaming reader for a stored blob.
+class RunDataStream(ABC):
+    """Streaming reader for stored run data.
 
     The shape mirrors Azure SDK's ``StorageStreamDownloader.chunks()`` so
     the existing call site in ``blobstream.py`` works unchanged for both
@@ -38,42 +39,44 @@ class BlobStream(ABC):
 
     @abstractmethod
     def chunks(self) -> Iterator[bytes]:
-        """Yield successive chunks of the blob's content."""
+        """Yield successive chunks of the run data's content."""
 
 
 class StorageAdapter(ABC):
     """Abstract base class for large-result storage backends."""
 
     def __init__(self, config: dict) -> None:
-        event.listen(Run, "after_delete", self._delete_blob_after_run_delete)
+        event.listen(Run, "after_delete", self._delete_run_data_after_run_delete)
 
     @abstractmethod
-    def get_blob(self, blob_name: str) -> bytes:
-        """Return the full content of a blob as bytes."""
+    def get_run_data(self, name: str) -> bytes:
+        """Return the full content of a run-data entry as bytes."""
 
     @abstractmethod
-    def store_blob(self, blob_name: str, data: Union[IO, bytes]) -> None:
-        """Store data under the given blob name."""
+    def store_run_data(self, name: str, data: Union[IO, bytes]) -> None:
+        """Store data under the given run-data name."""
 
     @abstractmethod
-    def delete_blob(self, blob_name: str) -> None:
-        """Delete a blob. Must be idempotent (no error if missing)."""
+    def delete_run_data(self, name: str) -> None:
+        """Delete a run-data entry. Must be idempotent (no error if missing)."""
 
     @abstractmethod
-    def stream_blob(self, blob_name: str):
+    def stream_run_data(self, name: str):
         """Return a streaming reader exposing a ``chunks()`` iterator."""
 
-    def _delete_blob_after_run_delete(self, mapper, connection, target) -> None:
-        """Remove the associated blobs when a Run row is deleted."""
+    def _delete_run_data_after_run_delete(
+        self, mapper, connection, target
+    ) -> None:
+        """Remove the associated run data when a Run row is deleted."""
         if not getattr(target, "blob_storage_used", False):
             return
         try:
             if target.result:
-                self.delete_blob(target.result)
+                self.delete_run_data(target.result)
             if target.input:
-                self.delete_blob(target.input)
+                self.delete_run_data(target.input)
         except Exception as e:
-            error_msg = f"Failed to delete blob for run {target.id}: {e}"
+            error_msg = f"Failed to delete run data for run {target.id}: {e}"
             log.error(error_msg)
             raise RuntimeError(error_msg)
 

--- a/vantage6/vantage6/cli/algostore/start.py
+++ b/vantage6/vantage6/cli/algostore/start.py
@@ -18,6 +18,7 @@ from vantage6.cli.common.start import (
 )
 from vantage6.cli.context.algorithm_store import AlgorithmStoreContext
 from vantage6.cli.common.decorator import click_insert_context
+from vantage6.cli.globals import ServerMountPath
 
 
 @click.command()
@@ -61,7 +62,7 @@ def cli_algo_store_start(
     info("Pulling algorithm store image...")
     pull_infra_image(docker_client, image, InstanceType.ALGORITHM_STORE)
 
-    config_file = "/mnt/config.yaml"
+    config_file = ServerMountPath.CONFIG.value
     mounts = mount_config_file(ctx, config_file)
 
     src_mount = mount_source(mount_src)

--- a/vantage6/vantage6/cli/common/start.py
+++ b/vantage6/vantage6/cli/common/start.py
@@ -23,7 +23,7 @@ from vantage6.common.docker.addons import check_docker_running, pull_image
 from vantage6.cli.context import AlgorithmStoreContext, ServerContext
 from vantage6.cli.common.utils import print_log_worker
 from vantage6.cli.utils import check_config_name_allowed
-from vantage6.cli.globals import ServerGlobals, AlgoStoreGlobals
+from vantage6.cli.globals import AlgoStoreGlobals, ServerGlobals, ServerMountPath
 
 
 def check_for_start(ctx: AppContext, type_: InstanceType) -> DockerClient:
@@ -257,16 +257,19 @@ def mount_database(
         os.makedirs(dirname, exist_ok=True)
 
         # we're mounting the entire folder that contains the database
-        mount = docker.types.Mount("/mnt/database/", dirname, type="bind")
+        mount = docker.types.Mount(
+            ServerMountPath.DATABASE_DIR.value, dirname, type="bind"
+        )
+        db_uri = f"sqlite:///{ServerMountPath.DATABASE_DIR.value}{basename}"
 
         if type_ == InstanceType.SERVER:
             environment_vars = {
-                ServerGlobals.DB_URI_ENV_VAR.value: f"sqlite:////mnt/database/{basename}",
+                ServerGlobals.DB_URI_ENV_VAR.value: db_uri,
                 ServerGlobals.CONFIG_NAME_ENV_VAR.value: ctx.config_file_name,
             }
         elif type_ == InstanceType.ALGORITHM_STORE:
             environment_vars = {
-                AlgoStoreGlobals.DB_URI_ENV_VAR.value: f"sqlite:////mnt/database/{basename}",
+                AlgoStoreGlobals.DB_URI_ENV_VAR.value: db_uri,
                 AlgoStoreGlobals.CONFIG_NAME_ENV_VAR.value: ctx.config_file_name,
             }
     else:
@@ -277,6 +280,52 @@ def mount_database(
         info("Consider using the docker-compose method to start a server")
 
     return mount, environment_vars
+
+
+def mount_blob_storage(ctx: ServerContext) -> tuple[docker.types.Mount | None, dict]:
+    """
+    Mount the on-disk blob store for the file-based large_result_store backend.
+
+    If ``large_result_store.type`` is ``"file"`` the host directory must be
+    bind-mounted into the server container, otherwise blobs would accumulate
+    inside the (ephemeral) container filesystem. To shield beginners from
+    forgetting to set this up, the helper auto-defaults ``base_path`` to a
+    subdirectory of ``ctx.data_dir`` if the user hasn't specified one.
+
+    Parameters
+    ----------
+    ctx : ServerContext
+        The server context.
+
+    Returns
+    -------
+    tuple[docker.types.Mount | None, dict]
+        The bind mount (or ``None`` if not applicable) and the env-var dict
+        that pins the in-container path the server should use.
+    """
+    cfg = ctx.config.get("large_result_store", {}) or {}
+    if not cfg:
+        return None, {}
+    if cfg.get("type", "file") != "file":
+        return None, {}
+
+    base_path = cfg.get("base_path")
+    if base_path:
+        host_path = os.path.abspath(os.path.expanduser(base_path))
+    else:
+        host_path = str(ctx.data_dir / "blobs")
+        info(
+            f"large_result_store.base_path not set; defaulting to {host_path} "
+            "on host (auto-mounted into the server container)."
+        )
+
+    os.makedirs(host_path, exist_ok=True)
+    container_path = ServerMountPath.BLOB_STORAGE.value
+    info(f"Mounting blob storage host dir {host_path} -> {container_path}")
+
+    mount = docker.types.Mount(container_path, host_path, type="bind")
+    env = {ServerGlobals.BLOB_BASE_PATH_ENV_VAR.value: container_path}
+    return mount, env
 
 
 def attach_logs(container: Container, type_: InstanceType) -> None:

--- a/vantage6/vantage6/cli/common/start.py
+++ b/vantage6/vantage6/cli/common/start.py
@@ -284,22 +284,19 @@ def mount_database(
 
 def mount_run_data_storage(ctx: ServerContext) -> docker.types.Mount | None:
     """
-    Mount the on-disk run-data store for the file-based large_result_store
-    backend.
+    Mount the on-disk run-data store for the file-based
+    ``large_run_data_store`` backend.
 
-    If ``large_result_store.type`` is ``"file"``, ``<ctx.data_dir>/run_data``
-    on the host is bind-mounted into the server container at the default
-    in-container path. Otherwise run data would accumulate inside the
-    (ephemeral) container filesystem.
+    If ``large_run_data_store`` is ``"filesystem"``,
+    ``<ctx.data_dir>/run_data`` on the host is bind-mounted into the
+    server container at the default in-container path. Otherwise run
+    data would accumulate inside the (ephemeral) container filesystem.
 
     The CLI does not expose any knob for changing either side of this
     mount — operators who need a different layout should use the
     docker-compose deployment path instead.
     """
-    cfg = ctx.config.get("large_result_store", {}) or {}
-    if not cfg:
-        return None
-    if cfg.get("type", "file") != "file":
+    if ctx.config.get("large_run_data_store") != "filesystem":
         return None
 
     host_path = str(ctx.data_dir / "run_data")

--- a/vantage6/vantage6/cli/common/start.py
+++ b/vantage6/vantage6/cli/common/start.py
@@ -282,15 +282,19 @@ def mount_database(
     return mount, environment_vars
 
 
-def mount_blob_storage(ctx: ServerContext) -> tuple[docker.types.Mount | None, dict]:
+def mount_run_data_storage(
+    ctx: ServerContext,
+) -> tuple[docker.types.Mount | None, dict]:
     """
-    Mount the on-disk blob store for the file-based large_result_store backend.
+    Mount the on-disk run-data store for the file-based large_result_store
+    backend.
 
     If ``large_result_store.type`` is ``"file"`` the host directory must be
-    bind-mounted into the server container, otherwise blobs would accumulate
-    inside the (ephemeral) container filesystem. To shield beginners from
-    forgetting to set this up, the helper auto-defaults ``base_path`` to a
-    subdirectory of ``ctx.data_dir`` if the user hasn't specified one.
+    bind-mounted into the server container, otherwise run data would
+    accumulate inside the (ephemeral) container filesystem. To shield
+    users from forgetting to set this up, the helper auto-defaults
+    ``base_path`` to a subdirectory of ``ctx.data_dir`` if the user
+    hasn't specified one.
 
     Parameters
     ----------
@@ -313,18 +317,18 @@ def mount_blob_storage(ctx: ServerContext) -> tuple[docker.types.Mount | None, d
     if base_path:
         host_path = os.path.abspath(os.path.expanduser(base_path))
     else:
-        host_path = str(ctx.data_dir / "blobs")
+        host_path = str(ctx.data_dir / "run_data")
         info(
             f"large_result_store.base_path not set; defaulting to {host_path} "
             "on host (auto-mounted into the server container)."
         )
 
     os.makedirs(host_path, exist_ok=True)
-    container_path = ServerMountPath.BLOB_STORAGE.value
-    info(f"Mounting blob storage host dir {host_path} -> {container_path}")
+    container_path = ServerMountPath.RUN_DATA_STORAGE.value
+    info(f"Mounting run data storage host dir {host_path} -> {container_path}")
 
     mount = docker.types.Mount(container_path, host_path, type="bind")
-    env = {ServerGlobals.BLOB_BASE_PATH_ENV_VAR.value: container_path}
+    env = {ServerGlobals.RUN_DATA_BASE_PATH_ENV_VAR.value: container_path}
     return mount, env
 
 

--- a/vantage6/vantage6/cli/common/start.py
+++ b/vantage6/vantage6/cli/common/start.py
@@ -282,54 +282,32 @@ def mount_database(
     return mount, environment_vars
 
 
-def mount_run_data_storage(
-    ctx: ServerContext,
-) -> tuple[docker.types.Mount | None, dict]:
+def mount_run_data_storage(ctx: ServerContext) -> docker.types.Mount | None:
     """
     Mount the on-disk run-data store for the file-based large_result_store
     backend.
 
-    If ``large_result_store.type`` is ``"file"`` the host directory must be
-    bind-mounted into the server container, otherwise run data would
-    accumulate inside the (ephemeral) container filesystem. To shield
-    users from forgetting to set this up, the helper auto-defaults
-    ``base_path`` to a subdirectory of ``ctx.data_dir`` if the user
-    hasn't specified one.
+    If ``large_result_store.type`` is ``"file"``, ``<ctx.data_dir>/run_data``
+    on the host is bind-mounted into the server container at the default
+    in-container path. Otherwise run data would accumulate inside the
+    (ephemeral) container filesystem.
 
-    Parameters
-    ----------
-    ctx : ServerContext
-        The server context.
-
-    Returns
-    -------
-    tuple[docker.types.Mount | None, dict]
-        The bind mount (or ``None`` if not applicable) and the env-var dict
-        that pins the in-container path the server should use.
+    The CLI does not expose any knob for changing either side of this
+    mount — operators who need a different layout should use the
+    docker-compose deployment path instead.
     """
     cfg = ctx.config.get("large_result_store", {}) or {}
     if not cfg:
-        return None, {}
+        return None
     if cfg.get("type", "file") != "file":
-        return None, {}
+        return None
 
-    base_path = cfg.get("base_path")
-    if base_path:
-        host_path = os.path.abspath(os.path.expanduser(base_path))
-    else:
-        host_path = str(ctx.data_dir / "run_data")
-        info(
-            f"large_result_store.base_path not set; defaulting to {host_path} "
-            "on host (auto-mounted into the server container)."
-        )
-
+    host_path = str(ctx.data_dir / "run_data")
     os.makedirs(host_path, exist_ok=True)
     container_path = ServerMountPath.RUN_DATA_STORAGE.value
     info(f"Mounting run data storage host dir {host_path} -> {container_path}")
 
-    mount = docker.types.Mount(container_path, host_path, type="bind")
-    env = {ServerGlobals.RUN_DATA_BASE_PATH_ENV_VAR.value: container_path}
-    return mount, env
+    return docker.types.Mount(container_path, host_path, type="bind")
 
 
 def attach_logs(container: Container, type_: InstanceType) -> None:

--- a/vantage6/vantage6/cli/globals.py
+++ b/vantage6/vantage6/cli/globals.py
@@ -67,7 +67,6 @@ class ServerGlobals(str, Enum):
 
     DB_URI_ENV_VAR = "VANTAGE6_DB_URI"
     CONFIG_NAME_ENV_VAR = "VANTAGE6_CONFIG_NAME"
-    RUN_DATA_BASE_PATH_ENV_VAR = "VANTAGE6_RUN_DATA_BASE_PATH"
 
 
 class ServerMountPath(str, Enum):

--- a/vantage6/vantage6/cli/globals.py
+++ b/vantage6/vantage6/cli/globals.py
@@ -67,7 +67,7 @@ class ServerGlobals(str, Enum):
 
     DB_URI_ENV_VAR = "VANTAGE6_DB_URI"
     CONFIG_NAME_ENV_VAR = "VANTAGE6_CONFIG_NAME"
-    BLOB_BASE_PATH_ENV_VAR = "VANTAGE6_BLOB_BASE_PATH"
+    RUN_DATA_BASE_PATH_ENV_VAR = "VANTAGE6_RUN_DATA_BASE_PATH"
 
 
 class ServerMountPath(str, Enum):
@@ -77,7 +77,7 @@ class ServerMountPath(str, Enum):
     IMPORT_CONFIG = "/mnt/import.yaml"
     LOG_DIR = "/mnt/log/"
     DATABASE_DIR = "/mnt/database/"
-    BLOB_STORAGE = "/mnt/blobs"
+    RUN_DATA_STORAGE = "/mnt/run_data"
 
 
 class AlgoStoreGlobals(str, Enum):

--- a/vantage6/vantage6/cli/globals.py
+++ b/vantage6/vantage6/cli/globals.py
@@ -67,6 +67,17 @@ class ServerGlobals(str, Enum):
 
     DB_URI_ENV_VAR = "VANTAGE6_DB_URI"
     CONFIG_NAME_ENV_VAR = "VANTAGE6_CONFIG_NAME"
+    BLOB_BASE_PATH_ENV_VAR = "VANTAGE6_BLOB_BASE_PATH"
+
+
+class ServerMountPath(str, Enum):
+    """In-container bind-mount paths used by the server / algorithm-store CLI."""
+
+    CONFIG = "/mnt/config.yaml"
+    IMPORT_CONFIG = "/mnt/import.yaml"
+    LOG_DIR = "/mnt/log/"
+    DATABASE_DIR = "/mnt/database/"
+    BLOB_STORAGE = "/mnt/blobs"
 
 
 class AlgoStoreGlobals(str, Enum):

--- a/vantage6/vantage6/cli/server/import_.py
+++ b/vantage6/vantage6/cli/server/import_.py
@@ -4,7 +4,7 @@ from threading import Thread
 import click
 import docker
 from sqlalchemy.engine.url import make_url
-from vantage6.cli.globals import ServerGlobals
+from vantage6.cli.globals import ServerGlobals, ServerMountPath
 
 from vantage6.common import info, warning
 from vantage6.common.docker.addons import check_docker_running, pull_image
@@ -81,8 +81,12 @@ def cli_server_import(
 
     info("Creating mounts")
     mounts = [
-        docker.types.Mount("/mnt/config.yaml", str(ctx.config_file), type="bind"),
-        docker.types.Mount("/mnt/import.yaml", str(file), type="bind"),
+        docker.types.Mount(
+            ServerMountPath.CONFIG.value, str(ctx.config_file), type="bind"
+        ),
+        docker.types.Mount(
+            ServerMountPath.IMPORT_CONFIG.value, str(file), type="bind"
+        ),
     ]
 
     # FIXME: code duplication with cli_server_start()
@@ -108,10 +112,14 @@ def cli_server_import(
         os.makedirs(dirname, exist_ok=True)
 
         # we're mounting the entire folder that contains the database
-        mounts.append(docker.types.Mount("/mnt/database/", dirname, type="bind"))
+        mounts.append(
+            docker.types.Mount(
+                ServerMountPath.DATABASE_DIR.value, dirname, type="bind"
+            )
+        )
 
         environment_vars = {
-            ServerGlobals.DB_URI_ENV_VAR: f"sqlite:////mnt/database/{basename}"
+            ServerGlobals.DB_URI_ENV_VAR: f"sqlite:///{ServerMountPath.DATABASE_DIR.value}{basename}"
         }
 
     else:

--- a/vantage6/vantage6/cli/server/shell.py
+++ b/vantage6/vantage6/cli/server/shell.py
@@ -8,6 +8,7 @@ from vantage6.common import info, error, debug as debug_msg
 from vantage6.common.docker.addons import check_docker_running
 from vantage6.common.globals import APPNAME, InstanceType
 from vantage6.cli.context.server import ServerContext
+from vantage6.cli.globals import ServerMountPath
 from vantage6.cli.common.decorator import click_insert_context
 
 
@@ -45,7 +46,7 @@ def cli_server_shell(ctx: ServerContext) -> None:
                 "vserver-local",
                 "shell",
                 "-c",
-                "/mnt/config.yaml",
+                ServerMountPath.CONFIG.value,
             ]
         )
     except Exception as e:

--- a/vantage6/vantage6/cli/server/start.py
+++ b/vantage6/vantage6/cli/server/start.py
@@ -26,7 +26,7 @@ from vantage6.cli.common.start import (
     attach_logs,
     check_for_start,
     get_image,
-    mount_blob_storage,
+    mount_run_data_storage,
     mount_database,
     mount_source,
     pull_infra_image,
@@ -120,10 +120,12 @@ def cli_server_start(
     ]
 
     db_mount, environment_vars = mount_database(ctx, InstanceType.SERVER)
-    blob_mount, blob_env = mount_blob_storage(ctx)
+    run_data_mount, run_data_env = mount_run_data_storage(ctx)
 
-    mounts.extend(m for m in (mount_source(mount_src), db_mount, blob_mount) if m)
-    environment_vars = {**(environment_vars or {}), **blob_env}
+    mounts.extend(
+        m for m in (mount_source(mount_src), db_mount, run_data_mount) if m
+    )
+    environment_vars = {**(environment_vars or {}), **run_data_env}
 
     # Create a docker network for the server and other services like RabbitMQ
     # to reside in

--- a/vantage6/vantage6/cli/server/start.py
+++ b/vantage6/vantage6/cli/server/start.py
@@ -178,7 +178,23 @@ def cli_server_start(
     # The `ip` and `port` refer here to the ip and port within the container.
     # So we do not really care that is it listening on all interfaces.
     internal_port = 5000
-    cmd = _build_uwsgi_command(internal_port, config_file)
+    cmd = (
+        f"uwsgi --http :{internal_port} "
+        "--http-websockets "
+        "--http-chunked-input "
+        "--http-keepalive "
+        "--post-buffering 0 "
+        # Reject any single chunked-input part larger than this. Sized well
+        # above ``HTTP_UPLOAD_CHUNK_SIZE`` so friendly clients have headroom;
+        # protects the server from hostile or buggy clients sending
+        # multi-gigabyte chunks.
+        f"--chunked-input-limit {MAX_CHUNKED_INPUT_PART} "
+        "--gevent 1000 "
+        "--master --disable-logging "
+        "--callable app "
+        "--wsgi-file /vantage6/vantage6-server/vantage6/server/wsgi.py "
+        f"--pyargv {config_file}"
+    )
 
     info(cmd)
 
@@ -211,41 +227,6 @@ def cli_server_start(
 
     if attach:
         attach_logs(container, InstanceType.SERVER)
-
-
-def _build_uwsgi_command(internal_port: int, config_file: str) -> str:
-    """
-    Assemble the uwsgi launch command for the server container.
-
-    Returns a single shell-style string (uwsgi accepts repeated flags on its
-    own command line).
-    """
-    options: list[tuple[str, str | None]] = [
-        # HTTP front-end
-        ("http", f":{internal_port}"),
-        ("http-websockets", None),
-        ("http-chunked-input", None),
-        ("http-keepalive", None),
-        ("post-buffering", "0"),
-        # Reject any single chunked-input part larger than this. Sized well
-        # above ``HTTP_UPLOAD_CHUNK_SIZE`` so friendly clients have headroom;
-        # protects the server from hostile or buggy clients sending
-        # multi-gigabyte chunks.
-        ("chunked-input-limit", str(MAX_CHUNKED_INPUT_PART)),
-        # Concurrency model
-        ("gevent", "1000"),
-        # Process lifecycle and logging
-        ("master", None),
-        ("disable-logging", None),
-        # WSGI application entry point
-        ("callable", "app"),
-        ("wsgi-file", "/vantage6/vantage6-server/vantage6/server/wsgi.py"),
-        ("pyargv", config_file),
-    ]
-    parts = ["uwsgi"]
-    for flag, value in options:
-        parts.append(f"--{flag}" if value is None else f"--{flag} {value}")
-    return " ".join(parts)
 
 
 def _start_rabbitmq(

--- a/vantage6/vantage6/cli/server/start.py
+++ b/vantage6/vantage6/cli/server/start.py
@@ -11,8 +11,13 @@ from vantage6.common.globals import (
     InstanceType,
 )
 
-from vantage6.common.globals import Ports, DEFAULT_PROMETHEUS_EXPORTER_PORT
+from vantage6.common.globals import (
+    MAX_CHUNKED_INPUT_PART,
+    Ports,
+    DEFAULT_PROMETHEUS_EXPORTER_PORT,
+)
 from vantage6.cli.context.server import ServerContext
+from vantage6.cli.globals import ServerMountPath
 from vantage6.cli.rabbitmq.queue_manager import RabbitMQManager
 from vantage6.cli.server.common import stop_ui
 from vantage6.cli.common.decorator import click_insert_context
@@ -21,6 +26,7 @@ from vantage6.cli.common.start import (
     attach_logs,
     check_for_start,
     get_image,
+    mount_blob_storage,
     mount_database,
     mount_source,
     pull_infra_image,
@@ -105,19 +111,19 @@ def cli_server_start(
     pull_infra_image(docker_client, image, InstanceType.SERVER)
 
     info("Creating mounts")
-    config_file = "/mnt/config.yaml"
+    config_file = ServerMountPath.CONFIG.value
     mounts = [
         docker.types.Mount(config_file, str(ctx.config_file), type="bind"),
-        docker.types.Mount("/mnt/log/", str(ctx.log_dir), type="bind"),
+        docker.types.Mount(
+            ServerMountPath.LOG_DIR.value, str(ctx.log_dir), type="bind"
+        ),
     ]
 
-    src_mount = mount_source(mount_src)
-    if src_mount:
-        mounts.append(src_mount)
+    db_mount, environment_vars = mount_database(ctx, InstanceType.SERVER)
+    blob_mount, blob_env = mount_blob_storage(ctx)
 
-    mount, environment_vars = mount_database(ctx, InstanceType.SERVER)
-    if mount:
-        mounts.append(mount)
+    mounts.extend(m for m in (mount_source(mount_src), db_mount, blob_mount) if m)
+    environment_vars = {**(environment_vars or {}), **blob_env}
 
     # Create a docker network for the server and other services like RabbitMQ
     # to reside in
@@ -171,13 +177,7 @@ def cli_server_start(
     # The `ip` and `port` refer here to the ip and port within the container.
     # So we do not really care that is it listening on all interfaces.
     internal_port = 5000
-    cmd = (
-        f"uwsgi --http :{internal_port} --gevent 1000 --http-websockets "
-        "--http-chunked-input --http-keepalive --post-buffering 0 "
-        "--master --callable app --disable-logging "
-        "--wsgi-file /vantage6/vantage6-server/vantage6/server/wsgi.py "
-        f"--pyargv {config_file}"
-    )
+    cmd = _build_uwsgi_command(internal_port, config_file)
 
     info(cmd)
 
@@ -210,6 +210,41 @@ def cli_server_start(
 
     if attach:
         attach_logs(container, InstanceType.SERVER)
+
+
+def _build_uwsgi_command(internal_port: int, config_file: str) -> str:
+    """
+    Assemble the uwsgi launch command for the server container.
+
+    Returns a single shell-style string (uwsgi accepts repeated flags on its
+    own command line).
+    """
+    options: list[tuple[str, str | None]] = [
+        # HTTP front-end
+        ("http", f":{internal_port}"),
+        ("http-websockets", None),
+        ("http-chunked-input", None),
+        ("http-keepalive", None),
+        ("post-buffering", "0"),
+        # Reject any single chunked-input part larger than this. Sized well
+        # above ``HTTP_UPLOAD_CHUNK_SIZE`` so friendly clients have headroom;
+        # protects the server from hostile or buggy clients sending
+        # multi-gigabyte chunks.
+        ("chunked-input-limit", str(MAX_CHUNKED_INPUT_PART)),
+        # Concurrency model
+        ("gevent", "1000"),
+        # Process lifecycle and logging
+        ("master", None),
+        ("disable-logging", None),
+        # WSGI application entry point
+        ("callable", "app"),
+        ("wsgi-file", "/vantage6/vantage6-server/vantage6/server/wsgi.py"),
+        ("pyargv", config_file),
+    ]
+    parts = ["uwsgi"]
+    for flag, value in options:
+        parts.append(f"--{flag}" if value is None else f"--{flag} {value}")
+    return " ".join(parts)
 
 
 def _start_rabbitmq(

--- a/vantage6/vantage6/cli/server/start.py
+++ b/vantage6/vantage6/cli/server/start.py
@@ -120,12 +120,11 @@ def cli_server_start(
     ]
 
     db_mount, environment_vars = mount_database(ctx, InstanceType.SERVER)
-    run_data_mount, run_data_env = mount_run_data_storage(ctx)
+    run_data_mount = mount_run_data_storage(ctx)
 
     mounts.extend(
         m for m in (mount_source(mount_src), db_mount, run_data_mount) if m
     )
-    environment_vars = {**(environment_vars or {}), **run_data_env}
 
     # Create a docker network for the server and other services like RabbitMQ
     # to reside in


### PR DESCRIPTION
Introduces a local-filesystem backend for the large_result_store so deployments without Azure can keep results out of the relational DB. File storage becomes the default when the type key is omitted from the large_result_store block; the existing Azure backend is unchanged otherwise.

Storage layer
- New FileStorageService with atomic tempfile+rename writes, sharded {base}/{uuid[:2]}/{uuid} layout, and streaming reads.
- Storage adapter factory and base class extracted so backends share the SQLAlchemy after_delete listener and a common interface.

CLI
- mount_blob_storage auto-bind-mounts the host blob dir into the server container and exposes its in-container path via env var.
- Mount paths centralized in a ServerMountPath enum; mount-building in cli_server_start refactored to remove repetition.
- uwsgi command moved to a structured _build_uwsgi_command helper.

Chunked upload fix
- Client-side per-HTTP-chunk size split from the local-I/O chunk size (HTTP_UPLOAD_CHUNK_SIZE=256 KiB vs DEFAULT_CHUNK_SIZE=1 MiB). The former is what becomes a single HTTP chunked-encoding part on the wire; the latter governs file/disk reads.
- Server passes --chunked-input-limit=MAX_CHUNKED_INPUT_PART (16 MiB) to uwsgi so legitimate clients have headroom while obviously hostile bodies are rejected.
- Encryption stream defaults now use HTTP_UPLOAD_CHUNK_SIZE so future HTTP callers can't reintroduce 1 MiB-per-chunk uploads.
- blobstream.post converts the chunked-input IOError into a structured 413 (with the limit in the body) rather than a generic 500, so clients can self-diagnose.
- UwsgiChunkedStream's chunk_size parameter renamed to read_timeout_seconds with a sensible 30 s default; the previous 4096 was passed to uwsgi.chunked_read as a timeout (the API's only argument), making it effectively unbounded.

Tests
- Unit tests for FileStorageService streaming + cleanup.
- test_cleanup.py extended for file-backend after_delete coverage.
- End-to-end coverage of upload/cleanup/limit/concurrency/sub-task paths lives in the separate vantage6-integration-tests repo.